### PR TITLE
Add 10 SEO-oriented options articles and shared styling

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -585,6 +585,116 @@
                         <a href="blog6.html" class="btn btn-primary">Weiterlesen</a>
                     </div>
                 </div>
+                <div class="blog-card">
+                    <div class="blog-image">
+                        <img src="https://source.unsplash.com/800x600/?covered-call" alt="Covered Calls Schritt für Schritt" loading="lazy">
+                    </div>
+                    <div class="blog-content">
+                        <div class="blog-date">4. April 2025</div>
+                        <h3 class="blog-title">Covered Calls Schritt für Schritt</h3>
+                        <p class="blog-excerpt">Verdienen Sie zusätzliche Prämien durch den Verkauf gedeckter Calls auf Ihre Aktien.</p>
+                        <a href="blog7.html" class="btn btn-primary">Weiterlesen</a>
+                    </div>
+                </div>
+                <div class="blog-card">
+                    <div class="blog-image">
+                        <img src="https://source.unsplash.com/800x600/?put-option" alt="Portfolio-Absicherung mit Put-Optionen" loading="lazy">
+                    </div>
+                    <div class="blog-content">
+                        <div class="blog-date">1. April 2025</div>
+                        <h3 class="blog-title">Portfolio-Absicherung mit Put-Optionen</h3>
+                        <p class="blog-excerpt">Schützen Sie Ihr Depot vor Kursverlusten mit dem gezielten Einsatz von Puts.</p>
+                        <a href="blog8.html" class="btn btn-primary">Weiterlesen</a>
+                    </div>
+                </div>
+                <div class="blog-card">
+                    <div class="blog-image">
+                        <img src="https://source.unsplash.com/800x600/?greeks,finance" alt="Optionsgriechen verständlich erklärt" loading="lazy">
+                    </div>
+                    <div class="blog-content">
+                        <div class="blog-date">28. März 2025</div>
+                        <h3 class="blog-title">Optionsgriechen verständlich erklärt</h3>
+                        <p class="blog-excerpt">Delta, Gamma, Theta und Vega helfen Ihnen, Optionen präzise zu bewerten.</p>
+                        <a href="blog9.html" class="btn btn-primary">Weiterlesen</a>
+                    </div>
+                </div>
+                <div class="blog-card">
+                    <div class="blog-image">
+                        <img src="https://source.unsplash.com/800x600/?income,options" alt="Einnahmen mit Stillhalterstrategien" loading="lazy">
+                    </div>
+                    <div class="blog-content">
+                        <div class="blog-date">25. März 2025</div>
+                        <h3 class="blog-title">Einnahmen mit Stillhalterstrategien</h3>
+                        <p class="blog-excerpt">Cash Secured Puts und andere Strategien liefern stetige Optionsprämien.</p>
+                        <a href="blog10.html" class="btn btn-primary">Weiterlesen</a>
+                    </div>
+                </div>
+                <div class="blog-card">
+                    <div class="blog-image">
+                        <img src="https://source.unsplash.com/800x600/?taxes,finance" alt="Steuern im Optionshandel" loading="lazy">
+                    </div>
+                    <div class="blog-content">
+                        <div class="blog-date">20. März 2025</div>
+                        <h3 class="blog-title">Steuern im Optionshandel</h3>
+                        <p class="blog-excerpt">Alles Wichtige zur Besteuerung von Prämien und Verlusten in Deutschland.</p>
+                        <a href="blog11.html" class="btn btn-primary">Weiterlesen</a>
+                    </div>
+                </div>
+                <div class="blog-card">
+                    <div class="blog-image">
+                        <img src="https://source.unsplash.com/800x600/?volatility,charts" alt="Straddles und Strangles" loading="lazy">
+                    </div>
+                    <div class="blog-content">
+                        <div class="blog-date">15. März 2025</div>
+                        <h3 class="blog-title">Straddles und Strangles</h3>
+                        <p class="blog-excerpt">Neutral handeln und dennoch von starken Kursbewegungen profitieren.</p>
+                        <a href="blog12.html" class="btn btn-primary">Weiterlesen</a>
+                    </div>
+                </div>
+                <div class="blog-card">
+                    <div class="blog-image">
+                        <img src="https://source.unsplash.com/800x600/?risk-management" alt="Positionsgrößen im Optionshandel" loading="lazy">
+                    </div>
+                    <div class="blog-content">
+                        <div class="blog-date">10. März 2025</div>
+                        <h3 class="blog-title">Positionsgrößen im Optionshandel</h3>
+                        <p class="blog-excerpt">Mit klugem Positionsmanagement das Handelskonto langfristig schützen.</p>
+                        <a href="blog13.html" class="btn btn-primary">Weiterlesen</a>
+                    </div>
+                </div>
+                <div class="blog-card">
+                    <div class="blog-image">
+                        <img src="https://source.unsplash.com/800x600/?comparison,stock" alt="Optionshandel vs. Aktienhandel" loading="lazy">
+                    </div>
+                    <div class="blog-content">
+                        <div class="blog-date">5. März 2025</div>
+                        <h3 class="blog-title">Optionshandel vs. Aktienhandel</h3>
+                        <p class="blog-excerpt">Welche Anlageform passt zu Ihren Zielen? Ein direkter Vergleich.</p>
+                        <a href="blog14.html" class="btn btn-primary">Weiterlesen</a>
+                    </div>
+                </div>
+                <div class="blog-card">
+                    <div class="blog-image">
+                        <img src="https://source.unsplash.com/800x600/?small-investor" alt="Mit kleinem Kapital starten" loading="lazy">
+                    </div>
+                    <div class="blog-content">
+                        <div class="blog-date">28. Februar 2025</div>
+                        <h3 class="blog-title">Mit kleinem Kapital starten</h3>
+                        <p class="blog-excerpt">So gelingt der Einstieg in den Optionshandel auch mit begrenztem Budget.</p>
+                        <a href="blog15.html" class="btn btn-primary">Weiterlesen</a>
+                    </div>
+                </div>
+                <div class="blog-card">
+                    <div class="blog-image">
+                        <img src="https://source.unsplash.com/800x600/?technical-analysis" alt="Technische Analyse und Optionen" loading="lazy">
+                    </div>
+                    <div class="blog-content">
+                        <div class="blog-date">20. Februar 2025</div>
+                        <h3 class="blog-title">Technische Analyse und Optionen</h3>
+                        <p class="blog-excerpt">Chartsignale gezielt mit Optionsstrategien umsetzen.</p>
+                        <a href="blog16.html" class="btn btn-primary">Weiterlesen</a>
+                    </div>
+                </div>
             </div>
         </div>
     </section>

--- a/blog10.html
+++ b/blog10.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit-no">
+    <title>Einnahmen mit Stillhalterstrategien: Cash Secured Puts und mehr</title>
+    <meta name="description" content="Verdienen Sie regelmäßige Optionsprämien durch den Verkauf von Cash Secured Puts und anderen Stillhalterstrategien.">
+    <link rel="icon" href="Favicon.jpg" type="image/jpeg">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <nav>
+            <div class="nav-container">
+                <div class="logo">
+                    <a href="index.html"><img src="Logo.jpg" alt="Just Options Logo"></a>
+                </div>
+                <div id="mobileMenuToggle" class="mobile-menu">
+                    <i class="fas fa-bars"></i>
+                </div>
+                <ul id="navLinks" class="nav-links">
+                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
+
+    <section class="page-title">
+        <div class="container">
+            <h1>Einnahmen mit Stillhalterstrategien</h1>
+            <p>Regelmäßige Prämien durch den Verkauf von Optionen.</p>
+        </div>
+    </section>
+
+    <section>
+        <div class="container">
+            <div class="blog-content">
+                <h2>Einnahmen mit Stillhalterstrategien: Cash Secured Puts und mehr</h2>
+                <p>Stillhalterstrategien setzen darauf, Optionen zu verkaufen statt zu kaufen. Ziel ist es, Prämien zu vereinnahmen und von Zeitwertverfall zu profitieren.</p>
+
+                <h3>Cash Secured Put</h3>
+                <p>Beim Verkauf eines Cash Secured Put verpflichten Sie sich, eine Aktie zu einem festgelegten Preis zu kaufen. Sie hinterlegen den entsprechenden Betrag als Sicherheit und erhalten dafür eine attraktive Prämie.</p>
+
+                <h3>Weitere Strategien</h3>
+                <p>Neben dem Cash Secured Put gehören Covered Calls, Iron Condors und Credit Spreads zu beliebten Stillhalterstrategien. Sie bieten unterschiedliche Chancen-Risiko-Profile und lassen sich flexibel an Marktbedingungen anpassen.</p>
+
+                <h3>Risiken beachten</h3>
+                <p>Der Verkauf von Optionen kann bei starken Marktbewegungen zu Verlusten führen. Achten Sie auf ausreichende Margin und verwenden Sie strikte Risikoregeln.</p>
+
+                <h3>Fazit</h3>
+                <p>Stillhalterstrategien ermöglichen stetige Einnahmen, erfordern aber Disziplin und Kapital. Ausführliche Schritt-für-Schritt-Anleitungen bietet <a href="index.html#book">mein Buch</a>.</p>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-content">
+                <div class="logo-container">
+                    <img src="Logo.jpg" alt="Just Options Logo - Optionen strategisch nutzen" style="max-width: 120px; height: auto;" loading="lazy">
+                </div>
+                <ul class="footer-links">
+                    <li><a href="index.html#book">Das Buch</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                    <li><a href="impressum.html" target="_blank" rel="noopener">Impressum</a></li>
+                    <li><a href="datenschutz.html" target="_blank" rel="noopener">Datenschutz</a></li>
+                </ul>
+            </div>
+            <div class="social-icons">
+                <a href="https://www.linkedin.com/in/lehleiter/" target="_blank" rel="noopener"><i class="fab fa-linkedin"></i></a>
+                <a href="https://www.instagram.com/just_options.de/" target="_blank" rel="noopener"><i class="fab fa-instagram"></i></a>
+                <a href="https://t.me/just_options_com" target="_blank" rel="noopener"><i class="fab fa-telegram"></i></a>
+            </div>
+            <div class="copyright">
+                &copy; 2025 Lehleiter Investment Training. Alle Rechte vorbehalten.
+            </div>
+        </div>
+    </footer>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const mobileMenuToggle = document.getElementById('mobileMenuToggle');
+        const navLinks = document.getElementById('navLinks');
+
+        mobileMenuToggle.addEventListener('click', function() {
+            navLinks.classList.toggle('show');
+            document.body.style.overflow = navLinks.classList.contains('show') ? 'hidden' : 'auto';
+
+            const icon = mobileMenuToggle.querySelector('i');
+            if (navLinks.classList.contains('show')) {
+                icon.classList.remove('fa-bars');
+                icon.classList.add('fa-times');
+            } else {
+                icon.classList.remove('fa-times');
+                icon.classList.add('fa-bars');
+            }
+        });
+
+        const navLinkItems = navLinks.querySelectorAll('a');
+        navLinkItems.forEach(link => {
+            link.addEventListener('click', function() {
+                if (window.innerWidth <= 768) {
+                    navLinks.classList.remove('show');
+                    document.body.style.overflow = 'auto';
+                    const icon = mobileMenuToggle.querySelector('i');
+                    icon.classList.remove('fa-times');
+                    icon.classList.add('fa-bars');
+                }
+            });
+        });
+    });
+    </script>
+</body>
+</html>

--- a/blog11.html
+++ b/blog11.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit-no">
+    <title>Steuern im Optionshandel: So behalten Sie den Überblick</title>
+    <meta name="description" content="Erfahren Sie, wie Optionsprämien in Deutschland besteuert werden und welche Regeln für Verluste gelten.">
+    <link rel="icon" href="Favicon.jpg" type="image/jpeg">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <nav>
+            <div class="nav-container">
+                <div class="logo">
+                    <a href="index.html"><img src="Logo.jpg" alt="Just Options Logo"></a>
+                </div>
+                <div id="mobileMenuToggle" class="mobile-menu">
+                    <i class="fas fa-bars"></i>
+                </div>
+                <ul id="navLinks" class="nav-links">
+                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
+
+    <section class="page-title">
+        <div class="container">
+            <h1>Steuern im Optionshandel</h1>
+            <p>Alles Wichtige zur Besteuerung von Optionsprämien in Deutschland.</p>
+        </div>
+    </section>
+
+    <section>
+        <div class="container">
+            <div class="blog-content">
+                <h2>Steuern im Optionshandel: So behalten Sie den Überblick</h2>
+                <p>Gewinne aus dem Optionshandel unterliegen in Deutschland der Abgeltungsteuer. Wer die Regeln kennt, vermeidet unangenehme Überraschungen.</p>
+
+                <h3>Besteuerung von Prämien</h3>
+                <p>Optionsprämien gelten als Kapitalerträge und werden mit 25&nbsp;% plus Solidaritätszuschlag und ggf. Kirchensteuer besteuert. Die Abführung übernimmt in der Regel der Broker.</p>
+
+                <h3>Verlustverrechnung</h3>
+                <p>Verluste aus Optionsgeschäften können nur begrenzt mit Gewinnen verrechnet werden. Achten Sie darauf, entsprechende Nachweise für das Finanzamt zu sichern.</p>
+
+                <h3>Tipps für die Steuererklärung</h3>
+                <p>Bewahren Sie Abrechnungen sorgfältig auf und nutzen Sie die Jahressteuerbescheinigung Ihres Brokers. Spezielle Software kann die Erstellung der Anlage KAP erleichtern.</p>
+
+                <h3>Fazit</h3>
+                <p>Wer die steuerlichen Rahmenbedingungen kennt, handelt entspannter. Detaillierte Beispiele und Checklisten finden Sie in <a href="index.html#book">meinem Buch</a>.</p>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-content">
+                <div class="logo-container">
+                    <img src="Logo.jpg" alt="Just Options Logo - Optionen strategisch nutzen" style="max-width: 120px; height: auto;" loading="lazy">
+                </div>
+                <ul class="footer-links">
+                    <li><a href="index.html#book">Das Buch</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                    <li><a href="impressum.html" target="_blank" rel="noopener">Impressum</a></li>
+                    <li><a href="datenschutz.html" target="_blank" rel="noopener">Datenschutz</a></li>
+                </ul>
+            </div>
+            <div class="social-icons">
+                <a href="https://www.linkedin.com/in/lehleiter/" target="_blank" rel="noopener"><i class="fab fa-linkedin"></i></a>
+                <a href="https://www.instagram.com/just_options.de/" target="_blank" rel="noopener"><i class="fab fa-instagram"></i></a>
+                <a href="https://t.me/just_options_com" target="_blank" rel="noopener"><i class="fab fa-telegram"></i></a>
+            </div>
+            <div class="copyright">
+                &copy; 2025 Lehleiter Investment Training. Alle Rechte vorbehalten.
+            </div>
+        </div>
+    </footer>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const mobileMenuToggle = document.getElementById('mobileMenuToggle');
+        const navLinks = document.getElementById('navLinks');
+
+        mobileMenuToggle.addEventListener('click', function() {
+            navLinks.classList.toggle('show');
+            document.body.style.overflow = navLinks.classList.contains('show') ? 'hidden' : 'auto';
+
+            const icon = mobileMenuToggle.querySelector('i');
+            if (navLinks.classList.contains('show')) {
+                icon.classList.remove('fa-bars');
+                icon.classList.add('fa-times');
+            } else {
+                icon.classList.remove('fa-times');
+                icon.classList.add('fa-bars');
+            }
+        });
+
+        const navLinkItems = navLinks.querySelectorAll('a');
+        navLinkItems.forEach(link => {
+            link.addEventListener('click', function() {
+                if (window.innerWidth <= 768) {
+                    navLinks.classList.remove('show');
+                    document.body.style.overflow = 'auto';
+                    const icon = mobileMenuToggle.querySelector('i');
+                    icon.classList.remove('fa-times');
+                    icon.classList.add('fa-bars');
+                }
+            });
+        });
+    });
+    </script>
+</body>
+</html>

--- a/blog12.html
+++ b/blog12.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit-no">
+    <title>Straddles und Strangles: Profitieren von hoher Volatilität</title>
+    <meta name="description" content="Neutral handeln und dennoch von starken Kursbewegungen profitieren – so funktionieren Straddles und Strangles.">
+    <link rel="icon" href="Favicon.jpg" type="image/jpeg">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <nav>
+            <div class="nav-container">
+                <div class="logo">
+                    <a href="index.html"><img src="Logo.jpg" alt="Just Options Logo"></a>
+                </div>
+                <div id="mobileMenuToggle" class="mobile-menu">
+                    <i class="fas fa-bars"></i>
+                </div>
+                <ul id="navLinks" class="nav-links">
+                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
+
+    <section class="page-title">
+        <div class="container">
+            <h1>Straddles und Strangles</h1>
+            <p>Neutral handeln und auf große Bewegungen setzen.</p>
+        </div>
+    </section>
+
+    <section>
+        <div class="container">
+            <div class="blog-content">
+                <h2>Straddles und Strangles: Profitieren von hoher Volatilität</h2>
+                <p>Wenn Sie starke Kursbewegungen erwarten, aber die Richtung unklar ist, bieten Straddles und Strangles interessante Möglichkeiten. Beide Strategien sind neutral und setzen auf Volatilität.</p>
+
+                <h3>Was ist ein Straddle?</h3>
+                <p>Ein Long Straddle besteht aus dem gleichzeitigen Kauf einer Call- und Put-Option mit identischem Strike und Laufzeit. Der Gewinn entsteht, wenn der Kurs stark steigt oder fällt.</p>
+
+                <h3>Strangle als flexible Alternative</h3>
+                <p>Beim Strangle liegen die Strikes der Call- und Put-Option weiter auseinander. Dadurch ist die Strategie günstiger, benötigt aber größere Kursbewegungen, um profitabel zu sein.</p>
+
+                <h3>Risikomanagement</h3>
+                <p>Da beide Strategien vom Zeitwertverfall betroffen sind, ist ein klarer Ausstiegsplan wichtig. Häufig werden sie vor Bekanntgabe wichtiger Nachrichten eingesetzt.</p>
+
+                <h3>Fazit</h3>
+                <p>Straddles und Strangles eignen sich für erfahrene Händler, die von Volatilität profitieren möchten. Weitere Beispiele und Praxisanleitungen finden Sie in <a href="index.html#book">meinem Buch</a>.</p>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-content">
+                <div class="logo-container">
+                    <img src="Logo.jpg" alt="Just Options Logo - Optionen strategisch nutzen" style="max-width: 120px; height: auto;" loading="lazy">
+                </div>
+                <ul class="footer-links">
+                    <li><a href="index.html#book">Das Buch</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                    <li><a href="impressum.html" target="_blank" rel="noopener">Impressum</a></li>
+                    <li><a href="datenschutz.html" target="_blank" rel="noopener">Datenschutz</a></li>
+                </ul>
+            </div>
+            <div class="social-icons">
+                <a href="https://www.linkedin.com/in/lehleiter/" target="_blank" rel="noopener"><i class="fab fa-linkedin"></i></a>
+                <a href="https://www.instagram.com/just_options.de/" target="_blank" rel="noopener"><i class="fab fa-instagram"></i></a>
+                <a href="https://t.me/just_options_com" target="_blank" rel="noopener"><i class="fab fa-telegram"></i></a>
+            </div>
+            <div class="copyright">
+                &copy; 2025 Lehleiter Investment Training. Alle Rechte vorbehalten.
+            </div>
+        </div>
+    </footer>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const mobileMenuToggle = document.getElementById('mobileMenuToggle');
+        const navLinks = document.getElementById('navLinks');
+
+        mobileMenuToggle.addEventListener('click', function() {
+            navLinks.classList.toggle('show');
+            document.body.style.overflow = navLinks.classList.contains('show') ? 'hidden' : 'auto';
+
+            const icon = mobileMenuToggle.querySelector('i');
+            if (navLinks.classList.contains('show')) {
+                icon.classList.remove('fa-bars');
+                icon.classList.add('fa-times');
+            } else {
+                icon.classList.remove('fa-times');
+                icon.classList.add('fa-bars');
+            }
+        });
+
+        const navLinkItems = navLinks.querySelectorAll('a');
+        navLinkItems.forEach(link => {
+            link.addEventListener('click', function() {
+                if (window.innerWidth <= 768) {
+                    navLinks.classList.remove('show');
+                    document.body.style.overflow = 'auto';
+                    const icon = mobileMenuToggle.querySelector('i');
+                    icon.classList.remove('fa-times');
+                    icon.classList.add('fa-bars');
+                }
+            });
+        });
+    });
+    </script>
+</body>
+</html>

--- a/blog13.html
+++ b/blog13.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit-no">
+    <title>Positionsgrößen im Optionshandel: Regeln für ein gesundes Konto</title>
+    <meta name="description" content="Erfahren Sie, wie Sie mit der richtigen Positionsgröße Risiken kontrollieren und Ihr Handelskonto schützen.">
+    <link rel="icon" href="Favicon.jpg" type="image/jpeg">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <nav>
+            <div class="nav-container">
+                <div class="logo">
+                    <a href="index.html"><img src="Logo.jpg" alt="Just Options Logo"></a>
+                </div>
+                <div id="mobileMenuToggle" class="mobile-menu">
+                    <i class="fas fa-bars"></i>
+                </div>
+                <ul id="navLinks" class="nav-links">
+                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
+
+    <section class="page-title">
+        <div class="container">
+            <h1>Positionsgrößen im Optionshandel</h1>
+            <p>Mit der richtigen Positionsgröße Risiken begrenzen.</p>
+        </div>
+    </section>
+
+    <section>
+        <div class="container">
+            <div class="blog-content">
+                <h2>Positionsgrößen im Optionshandel: Regeln für ein gesundes Konto</h2>
+                <p>Eine durchdachte Positionsgröße ist entscheidend, um Drawdowns zu vermeiden und langfristig am Markt zu bestehen. Im Optionshandel spielt sie eine besonders große Rolle.</p>
+
+                <h3>Prozent vom Konto</h3>
+                <p>Viele Händler riskieren pro Trade maximal ein bis zwei Prozent des Kontowerts. Diese Faustregel schützt vor großen Verlusten und sorgt für Konstanz.</p>
+
+                <h3>Diversifikation</h3>
+                <p>Verteilen Sie Ihre Positionen auf verschiedene Basiswerte und Strategien. So vermeiden Sie Klumpenrisiken und glätten die Schwankungen Ihres Portfolios.</p>
+
+                <h3>Anpassung an Volatilität</h3>
+                <p>In Phasen hoher Volatilität sollten Positionsgrößen reduziert werden. Eine höhere implizite Volatilität bedeutet höhere Prämien, aber auch größere Kursschwankungen.</p>
+
+                <h3>Fazit</h3>
+                <p>Mit konsequentem Positionsgrößenmanagement schützen Sie Ihr Kapital und handeln entspannter. Weitere Praxisbeispiele finden Sie in <a href="index.html#book">meinem Buch</a>.</p>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-content">
+                <div class="logo-container">
+                    <img src="Logo.jpg" alt="Just Options Logo - Optionen strategisch nutzen" style="max-width: 120px; height: auto;" loading="lazy">
+                </div>
+                <ul class="footer-links">
+                    <li><a href="index.html#book">Das Buch</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                    <li><a href="impressum.html" target="_blank" rel="noopener">Impressum</a></li>
+                    <li><a href="datenschutz.html" target="_blank" rel="noopener">Datenschutz</a></li>
+                </ul>
+            </div>
+            <div class="social-icons">
+                <a href="https://www.linkedin.com/in/lehleiter/" target="_blank" rel="noopener"><i class="fab fa-linkedin"></i></a>
+                <a href="https://www.instagram.com/just_options.de/" target="_blank" rel="noopener"><i class="fab fa-instagram"></i></a>
+                <a href="https://t.me/just_options_com" target="_blank" rel="noopener"><i class="fab fa-telegram"></i></a>
+            </div>
+            <div class="copyright">
+                &copy; 2025 Lehleiter Investment Training. Alle Rechte vorbehalten.
+            </div>
+        </div>
+    </footer>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const mobileMenuToggle = document.getElementById('mobileMenuToggle');
+        const navLinks = document.getElementById('navLinks');
+
+        mobileMenuToggle.addEventListener('click', function() {
+            navLinks.classList.toggle('show');
+            document.body.style.overflow = navLinks.classList.contains('show') ? 'hidden' : 'auto';
+
+            const icon = mobileMenuToggle.querySelector('i');
+            if (navLinks.classList.contains('show')) {
+                icon.classList.remove('fa-bars');
+                icon.classList.add('fa-times');
+            } else {
+                icon.classList.remove('fa-times');
+                icon.classList.add('fa-bars');
+            }
+        });
+
+        const navLinkItems = navLinks.querySelectorAll('a');
+        navLinkItems.forEach(link => {
+            link.addEventListener('click', function() {
+                if (window.innerWidth <= 768) {
+                    navLinks.classList.remove('show');
+                    document.body.style.overflow = 'auto';
+                    const icon = mobileMenuToggle.querySelector('i');
+                    icon.classList.remove('fa-times');
+                    icon.classList.add('fa-bars');
+                }
+            });
+        });
+    });
+    </script>
+</body>
+</html>

--- a/blog14.html
+++ b/blog14.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit-no">
+    <title>Optionshandel vs. Aktienhandel: Die wichtigsten Unterschiede</title>
+    <meta name="description" content="Vergleichen Sie Chancen und Risiken von Options- und Aktienhandel und finden Sie heraus, was zu Ihnen passt.">
+    <link rel="icon" href="Favicon.jpg" type="image/jpeg">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <nav>
+            <div class="nav-container">
+                <div class="logo">
+                    <a href="index.html"><img src="Logo.jpg" alt="Just Options Logo"></a>
+                </div>
+                <div id="mobileMenuToggle" class="mobile-menu">
+                    <i class="fas fa-bars"></i>
+                </div>
+                <ul id="navLinks" class="nav-links">
+                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
+
+    <section class="page-title">
+        <div class="container">
+            <h1>Optionshandel vs. Aktienhandel</h1>
+            <p>Wann sich der Handel mit Optionen lohnt.</p>
+        </div>
+    </section>
+
+    <section>
+        <div class="container">
+            <div class="blog-content">
+                <h2>Optionshandel vs. Aktienhandel: Die wichtigsten Unterschiede</h2>
+                <p>Aktien und Optionen bieten unterschiedliche Chancen und Risiken. Während Aktien langfristig an Unternehmenserfolgen teilhaben lassen, ermöglichen Optionen flexible Strategien und Hebelwirkung.</p>
+
+                <h3>Flexibilität und Hebel</h3>
+                <p>Optionen erlauben es, auf steigende, fallende oder seitwärts laufende Märkte zu setzen. Durch den Hebel kann mit wenig Kapital eine große Position bewegt werden.</p>
+
+                <h3>Risiko und Kapitaleinsatz</h3>
+                <p>Beim Aktienkauf ist das Risiko auf den Kaufpreis begrenzt. Optionsstrategien können jedoch komplexer sein und erfordern ein klares Risikomanagement.</p>
+
+                <h3>Geeignete Einsatzbereiche</h3>
+                <p>Aktien eignen sich für langfristige Investitionen. Optionen werden häufig für Einkommen, Absicherung oder kurzfristige Spekulationen genutzt.</p>
+
+                <h3>Fazit</h3>
+                <p>Beide Anlageformen haben ihre Berechtigung. Wer Optionen gezielt einsetzt, erweitert seine Möglichkeiten erheblich. Ausführliche Vergleiche finden Sie in <a href="index.html#book">meinem Buch</a>.</p>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-content">
+                <div class="logo-container">
+                    <img src="Logo.jpg" alt="Just Options Logo - Optionen strategisch nutzen" style="max-width: 120px; height: auto;" loading="lazy">
+                </div>
+                <ul class="footer-links">
+                    <li><a href="index.html#book">Das Buch</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                    <li><a href="impressum.html" target="_blank" rel="noopener">Impressum</a></li>
+                    <li><a href="datenschutz.html" target="_blank" rel="noopener">Datenschutz</a></li>
+                </ul>
+            </div>
+            <div class="social-icons">
+                <a href="https://www.linkedin.com/in/lehleiter/" target="_blank" rel="noopener"><i class="fab fa-linkedin"></i></a>
+                <a href="https://www.instagram.com/just_options.de/" target="_blank" rel="noopener"><i class="fab fa-instagram"></i></a>
+                <a href="https://t.me/just_options_com" target="_blank" rel="noopener"><i class="fab fa-telegram"></i></a>
+            </div>
+            <div class="copyright">
+                &copy; 2025 Lehleiter Investment Training. Alle Rechte vorbehalten.
+            </div>
+        </div>
+    </footer>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const mobileMenuToggle = document.getElementById('mobileMenuToggle');
+        const navLinks = document.getElementById('navLinks');
+
+        mobileMenuToggle.addEventListener('click', function() {
+            navLinks.classList.toggle('show');
+            document.body.style.overflow = navLinks.classList.contains('show') ? 'hidden' : 'auto';
+
+            const icon = mobileMenuToggle.querySelector('i');
+            if (navLinks.classList.contains('show')) {
+                icon.classList.remove('fa-bars');
+                icon.classList.add('fa-times');
+            } else {
+                icon.classList.remove('fa-times');
+                icon.classList.add('fa-bars');
+            }
+        });
+
+        const navLinkItems = navLinks.querySelectorAll('a');
+        navLinkItems.forEach(link => {
+            link.addEventListener('click', function() {
+                if (window.innerWidth <= 768) {
+                    navLinks.classList.remove('show');
+                    document.body.style.overflow = 'auto';
+                    const icon = mobileMenuToggle.querySelector('i');
+                    icon.classList.remove('fa-times');
+                    icon.classList.add('fa-bars');
+                }
+            });
+        });
+    });
+    </script>
+</body>
+</html>

--- a/blog15.html
+++ b/blog15.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit-no">
+    <title>Mit kleinem Kapital in den Optionshandel starten</title>
+    <meta name="description" content="Tipps und Strategien, wie Sie auch mit wenig Geld erfolgreich in den Optionshandel einsteigen.">
+    <link rel="icon" href="Favicon.jpg" type="image/jpeg">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <nav>
+            <div class="nav-container">
+                <div class="logo">
+                    <a href="index.html"><img src="Logo.jpg" alt="Just Options Logo"></a>
+                </div>
+                <div id="mobileMenuToggle" class="mobile-menu">
+                    <i class="fas fa-bars"></i>
+                </div>
+                <ul id="navLinks" class="nav-links">
+                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
+
+    <section class="page-title">
+        <div class="container">
+            <h1>Mit kleinem Kapital starten</h1>
+            <p>So bauen Sie ein Optionsportfolio auch mit wenig Geld auf.</p>
+        </div>
+    </section>
+
+    <section>
+        <div class="container">
+            <div class="blog-content">
+                <h2>Mit kleinem Kapital in den Optionshandel starten</h2>
+                <p>Nicht jeder verfügt über ein großes Budget. Trotzdem lässt sich der Optionshandel mit überschaubarem Kapital beginnen, wenn Sie einige Grundregeln beachten.</p>
+
+                <h3>Brokerwahl und Kontogröße</h3>
+                <p>Suchen Sie einen Broker mit niedrigen Gebühren und der Möglichkeit, Kleinstkonten zu führen. Manche Broker erlauben den Handel bereits ab wenigen hundert Euro.</p>
+
+                <h3>Geeignete Strategien</h3>
+                <p>Konzentrieren Sie sich auf einfache Strategien wie Covered Calls oder Cash Secured Puts. Vermeiden Sie komplexe Spreads, die hohe Marginanforderungen haben.</p>
+
+                <h3>Kosten im Blick</h3>
+                <p>Achten Sie auf Transaktionskosten und die Höhe der Optionsprämie. Kleine Konten profitieren besonders von günstigen Gebührenstrukturen.</p>
+
+                <h3>Fazit</h3>
+                <p>Auch mit wenig Kapital können Sie Erfahrung im Optionshandel sammeln. Wie Sie Schritt für Schritt vorgehen, erfahren Sie ausführlich in <a href="index.html#book">meinem Buch</a>.</p>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-content">
+                <div class="logo-container">
+                    <img src="Logo.jpg" alt="Just Options Logo - Optionen strategisch nutzen" style="max-width: 120px; height: auto;" loading="lazy">
+                </div>
+                <ul class="footer-links">
+                    <li><a href="index.html#book">Das Buch</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                    <li><a href="impressum.html" target="_blank" rel="noopener">Impressum</a></li>
+                    <li><a href="datenschutz.html" target="_blank" rel="noopener">Datenschutz</a></li>
+                </ul>
+            </div>
+            <div class="social-icons">
+                <a href="https://www.linkedin.com/in/lehleiter/" target="_blank" rel="noopener"><i class="fab fa-linkedin"></i></a>
+                <a href="https://www.instagram.com/just_options.de/" target="_blank" rel="noopener"><i class="fab fa-instagram"></i></a>
+                <a href="https://t.me/just_options_com" target="_blank" rel="noopener"><i class="fab fa-telegram"></i></a>
+            </div>
+            <div class="copyright">
+                &copy; 2025 Lehleiter Investment Training. Alle Rechte vorbehalten.
+            </div>
+        </div>
+    </footer>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const mobileMenuToggle = document.getElementById('mobileMenuToggle');
+        const navLinks = document.getElementById('navLinks');
+
+        mobileMenuToggle.addEventListener('click', function() {
+            navLinks.classList.toggle('show');
+            document.body.style.overflow = navLinks.classList.contains('show') ? 'hidden' : 'auto';
+
+            const icon = mobileMenuToggle.querySelector('i');
+            if (navLinks.classList.contains('show')) {
+                icon.classList.remove('fa-bars');
+                icon.classList.add('fa-times');
+            } else {
+                icon.classList.remove('fa-times');
+                icon.classList.add('fa-bars');
+            }
+        });
+
+        const navLinkItems = navLinks.querySelectorAll('a');
+        navLinkItems.forEach(link => {
+            link.addEventListener('click', function() {
+                if (window.innerWidth <= 768) {
+                    navLinks.classList.remove('show');
+                    document.body.style.overflow = 'auto';
+                    const icon = mobileMenuToggle.querySelector('i');
+                    icon.classList.remove('fa-times');
+                    icon.classList.add('fa-bars');
+                }
+            });
+        });
+    });
+    </script>
+</body>
+</html>

--- a/blog16.html
+++ b/blog16.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit-no">
+    <title>Technische Analyse und Optionen: Effektive Kombination für Trader</title>
+    <meta name="description" content="Erfahren Sie, wie Charttechnik und Optionsstrategien zusammenwirken, um präzisere Trades zu ermöglichen.">
+    <link rel="icon" href="Favicon.jpg" type="image/jpeg">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <nav>
+            <div class="nav-container">
+                <div class="logo">
+                    <a href="index.html"><img src="Logo.jpg" alt="Just Options Logo"></a>
+                </div>
+                <div id="mobileMenuToggle" class="mobile-menu">
+                    <i class="fas fa-bars"></i>
+                </div>
+                <ul id="navLinks" class="nav-links">
+                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
+
+    <section class="page-title">
+        <div class="container">
+            <h1>Technische Analyse und Optionen</h1>
+            <p>Chartmuster mit Optionsstrategien verbinden.</p>
+        </div>
+    </section>
+
+    <section>
+        <div class="container">
+            <div class="blog-content">
+                <h2>Technische Analyse und Optionen: Effektive Kombination für Trader</h2>
+                <p>Technische Analyse liefert präzise Einstiegs- und Ausstiegssignale. In Kombination mit Optionen lassen sich diese Signale gezielt nutzen und das Risiko steuern.</p>
+
+                <h3>Trendlinien und Optionen</h3>
+                <p>Wer Trendlinien einsetzt, kann Breakouts mit Call- oder Put-Optionen handeln. Ein bestätigter Ausbruch bietet oft gute Chancen für kurzfristige Strategien.</p>
+
+                <h3>Indikatoren für den Einstieg</h3>
+                <p>Gleitende Durchschnitte, RSI oder Bollinger-Bänder helfen, Überkauft- und Überverkauft-Situationen zu erkennen. Optionen ermöglichen es, diese Signale mit begrenztem Risiko zu spielen.</p>
+
+                <h3>Kombination mit Risikomanagement</h3>
+                <p>Setzen Sie Stop-Loss-Marken anhand technischer Marken und wählen Sie passende Optionsstrategien wie Spreads, um Risiken zu begrenzen.</p>
+
+                <h3>Fazit</h3>
+                <p>Die Verbindung von Charttechnik und Optionen eröffnet zusätzliche Handelsmöglichkeiten. Detaillierte Praxisbeispiele finden Sie in <a href="index.html#book">meinem Buch</a>.</p>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-content">
+                <div class="logo-container">
+                    <img src="Logo.jpg" alt="Just Options Logo - Optionen strategisch nutzen" style="max-width: 120px; height: auto;" loading="lazy">
+                </div>
+                <ul class="footer-links">
+                    <li><a href="index.html#book">Das Buch</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                    <li><a href="impressum.html" target="_blank" rel="noopener">Impressum</a></li>
+                    <li><a href="datenschutz.html" target="_blank" rel="noopener">Datenschutz</a></li>
+                </ul>
+            </div>
+            <div class="social-icons">
+                <a href="https://www.linkedin.com/in/lehleiter/" target="_blank" rel="noopener"><i class="fab fa-linkedin"></i></a>
+                <a href="https://www.instagram.com/just_options.de/" target="_blank" rel="noopener"><i class="fab fa-instagram"></i></a>
+                <a href="https://t.me/just_options_com" target="_blank" rel="noopener"><i class="fab fa-telegram"></i></a>
+            </div>
+            <div class="copyright">
+                &copy; 2025 Lehleiter Investment Training. Alle Rechte vorbehalten.
+            </div>
+        </div>
+    </footer>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const mobileMenuToggle = document.getElementById('mobileMenuToggle');
+        const navLinks = document.getElementById('navLinks');
+
+        mobileMenuToggle.addEventListener('click', function() {
+            navLinks.classList.toggle('show');
+            document.body.style.overflow = navLinks.classList.contains('show') ? 'hidden' : 'auto';
+
+            const icon = mobileMenuToggle.querySelector('i');
+            if (navLinks.classList.contains('show')) {
+                icon.classList.remove('fa-bars');
+                icon.classList.add('fa-times');
+            } else {
+                icon.classList.remove('fa-times');
+                icon.classList.add('fa-bars');
+            }
+        });
+
+        const navLinkItems = navLinks.querySelectorAll('a');
+        navLinkItems.forEach(link => {
+            link.addEventListener('click', function() {
+                if (window.innerWidth <= 768) {
+                    navLinks.classList.remove('show');
+                    document.body.style.overflow = 'auto';
+                    const icon = mobileMenuToggle.querySelector('i');
+                    icon.classList.remove('fa-times');
+                    icon.classList.add('fa-bars');
+                }
+            });
+        });
+    });
+    </script>
+</body>
+</html>

--- a/blog7.html
+++ b/blog7.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+    <title>Covered Calls Schritt für Schritt: Zusatzeinnahmen mit Aktien generieren</title>
+    <meta name="description" content="Lernen Sie, wie Sie mit Covered Calls regelmäßige Prämien erzielen und Ihr Aktienportfolio effizienter nutzen.">
+    <link rel="icon" href="Favicon.jpg" type="image/jpeg">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <nav>
+            <div class="nav-container">
+                <div class="logo">
+                    <a href="index.html"><img src="Logo.jpg" alt="Just Options Logo"></a>
+                </div>
+                <div id="mobileMenuToggle" class="mobile-menu">
+                    <i class="fas fa-bars"></i>
+                </div>
+                <ul id="navLinks" class="nav-links">
+                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
+
+    <section class="page-title">
+        <div class="container">
+            <h1>Covered Calls Schritt für Schritt</h1>
+            <p>Zusatzeinnahmen durch den Verkauf von Call-Optionen auf eigene Aktien.</p>
+        </div>
+    </section>
+
+    <section>
+        <div class="container">
+            <div class="blog-content">
+                <h2>Covered Calls Schritt für Schritt: Zusatzeinnahmen mit Aktien generieren</h2>
+                <p>Covered Calls sind eine beliebte Strategie, um mit bestehenden Aktienpositionen zusätzliche Einnahmen zu erzielen. Durch den Verkauf von Call-Optionen verpflichten Sie sich, Ihre Aktien zu einem festgelegten Preis zu verkaufen und erhalten dafür eine Optionsprämie.</p>
+
+                <h3>Was ist ein Covered Call?</h3>
+                <p>Bei einem Covered Call besitzen Sie die zugrunde liegende Aktie und verkaufen gleichzeitig eine Call-Option darauf. Dadurch ist die Position "gedeckt" und das Risiko begrenzt.</p>
+
+                <h3>So setzen Sie die Strategie um</h3>
+                <p>Wählen Sie eine Aktie aus Ihrem Portfolio, legen Sie einen Strike-Preis leicht über dem aktuellen Kurs fest und verkaufen Sie eine Call-Option mit kurzer Laufzeit. Die eingenommene Prämie bietet einen Puffer gegen Kursrückgänge.</p>
+
+                <h3>Vorteile und Risiken</h3>
+                <p>Covered Calls generieren laufende Einnahmen und senken die Volatilität des Portfolios. Gleichzeitig geben Sie jedoch das Aufwärtspotenzial der Aktie oberhalb des Strike-Preises ab.</p>
+
+                <h3>Fazit</h3>
+                <p>Mit Covered Calls können Sie Ihre Rendite erhöhen, ohne zusätzliche Mittel einzusetzen. Eine ausführliche Anleitung und weitere Strategien finden Sie in <a href="index.html#book">meinem Buch</a>.</p>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-content">
+                <div class="logo-container">
+                    <img src="Logo.jpg" alt="Just Options Logo - Optionen strategisch nutzen" style="max-width: 120px; height: auto;" loading="lazy">
+                </div>
+                <ul class="footer-links">
+                    <li><a href="index.html#book">Das Buch</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                    <li><a href="impressum.html" target="_blank" rel="noopener">Impressum</a></li>
+                    <li><a href="datenschutz.html" target="_blank" rel="noopener">Datenschutz</a></li>
+                </ul>
+            </div>
+            <div class="social-icons">
+                <a href="https://www.linkedin.com/in/lehleiter/" target="_blank" rel="noopener"><i class="fab fa-linkedin"></i></a>
+                <a href="https://www.instagram.com/just_options.de/" target="_blank" rel="noopener"><i class="fab fa-instagram"></i></a>
+                <a href="https://t.me/just_options_com" target="_blank" rel="noopener"><i class="fab fa-telegram"></i></a>
+            </div>
+            <div class="copyright">
+                &copy; 2025 Lehleiter Investment Training. Alle Rechte vorbehalten.
+            </div>
+        </div>
+    </footer>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const mobileMenuToggle = document.getElementById('mobileMenuToggle');
+        const navLinks = document.getElementById('navLinks');
+
+        mobileMenuToggle.addEventListener('click', function() {
+            navLinks.classList.toggle('show');
+            document.body.style.overflow = navLinks.classList.contains('show') ? 'hidden' : 'auto';
+
+            const icon = mobileMenuToggle.querySelector('i');
+            if (navLinks.classList.contains('show')) {
+                icon.classList.remove('fa-bars');
+                icon.classList.add('fa-times');
+            } else {
+                icon.classList.remove('fa-times');
+                icon.classList.add('fa-bars');
+            }
+        });
+
+        const navLinkItems = navLinks.querySelectorAll('a');
+        navLinkItems.forEach(link => {
+            link.addEventListener('click', function() {
+                if (window.innerWidth <= 768) {
+                    navLinks.classList.remove('show');
+                    document.body.style.overflow = 'auto';
+                    const icon = mobileMenuToggle.querySelector('i');
+                    icon.classList.remove('fa-times');
+                    icon.classList.add('fa-bars');
+                }
+            });
+        });
+    });
+    </script>
+</body>
+</html>

--- a/blog8.html
+++ b/blog8.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+    <title>Portfolio-Absicherung mit Put-Optionen: Der ultimative Leitfaden</title>
+    <meta name="description" content="So schützen Sie Ihr Depot effektiv mit Put-Optionen und reduzieren Verlustrisiken.">
+    <link rel="icon" href="Favicon.jpg" type="image/jpeg">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <nav>
+            <div class="nav-container">
+                <div class="logo">
+                    <a href="index.html"><img src="Logo.jpg" alt="Just Options Logo"></a>
+                </div>
+                <div id="mobileMenuToggle" class="mobile-menu">
+                    <i class="fas fa-bars"></i>
+                </div>
+                <ul id="navLinks" class="nav-links">
+                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
+
+    <section class="page-title">
+        <div class="container">
+            <h1>Portfolio-Absicherung mit Put-Optionen</h1>
+            <p>So schützen Sie Ihr Depot vor starken Kursverlusten.</p>
+        </div>
+    </section>
+
+    <section>
+        <div class="container">
+            <div class="blog-content">
+                <h2>Portfolio-Absicherung mit Put-Optionen: Der ultimative Leitfaden</h2>
+                <p>Put-Optionen bieten Anlegern die Möglichkeit, sich gegen fallende Kurse abzusichern. Durch den Kauf eines Puts erhalten Sie das Recht, eine Aktie zu einem festgelegten Preis zu verkaufen.</p>
+
+                <h3>Wie funktioniert eine Put-Option?</h3>
+                <p>Eine Put-Option steigt im Wert, wenn der Kurs des Basiswerts fällt. Sie eignet sich daher ideal zur Absicherung bestehender Positionen oder eines gesamten Portfolios.</p>
+
+                <h3>Die richtige Laufzeit wählen</h3>
+                <p>Die Laufzeit der Option sollte den Zeitraum abdecken, den Sie absichern möchten. Kürzere Laufzeiten sind günstiger, bieten aber weniger Schutz.</p>
+
+                <h3>Kosten und Nutzen abwägen</h3>
+                <p>Der Schutz durch Puts ist nicht kostenlos. Achten Sie darauf, dass die gezahlte Prämie in einem vernünftigen Verhältnis zum Risiko steht.</p>
+
+                <h3>Fazit</h3>
+                <p>Put-Optionen sind ein wirkungsvolles Instrument zur Depotabsicherung. Mehr Strategien und Beispiele finden Sie in <a href="index.html#book">meinem Buch</a>.</p>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-content">
+                <div class="logo-container">
+                    <img src="Logo.jpg" alt="Just Options Logo - Optionen strategisch nutzen" style="max-width: 120px; height: auto;" loading="lazy">
+                </div>
+                <ul class="footer-links">
+                    <li><a href="index.html#book">Das Buch</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                    <li><a href="impressum.html" target="_blank" rel="noopener">Impressum</a></li>
+                    <li><a href="datenschutz.html" target="_blank" rel="noopener">Datenschutz</a></li>
+                </ul>
+            </div>
+            <div class="social-icons">
+                <a href="https://www.linkedin.com/in/lehleiter/" target="_blank" rel="noopener"><i class="fab fa-linkedin"></i></a>
+                <a href="https://www.instagram.com/just_options.de/" target="_blank" rel="noopener"><i class="fab fa-instagram"></i></a>
+                <a href="https://t.me/just_options_com" target="_blank" rel="noopener"><i class="fab fa-telegram"></i></a>
+            </div>
+            <div class="copyright">
+                &copy; 2025 Lehleiter Investment Training. Alle Rechte vorbehalten.
+            </div>
+        </div>
+    </footer>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const mobileMenuToggle = document.getElementById('mobileMenuToggle');
+        const navLinks = document.getElementById('navLinks');
+
+        mobileMenuToggle.addEventListener('click', function() {
+            navLinks.classList.toggle('show');
+            document.body.style.overflow = navLinks.classList.contains('show') ? 'hidden' : 'auto';
+
+            const icon = mobileMenuToggle.querySelector('i');
+            if (navLinks.classList.contains('show')) {
+                icon.classList.remove('fa-bars');
+                icon.classList.add('fa-times');
+            } else {
+                icon.classList.remove('fa-times');
+                icon.classList.add('fa-bars');
+            }
+        });
+
+        const navLinkItems = navLinks.querySelectorAll('a');
+        navLinkItems.forEach(link => {
+            link.addEventListener('click', function() {
+                if (window.innerWidth <= 768) {
+                    navLinks.classList.remove('show');
+                    document.body.style.overflow = 'auto';
+                    const icon = mobileMenuToggle.querySelector('i');
+                    icon.classList.remove('fa-times');
+                    icon.classList.add('fa-bars');
+                }
+            });
+        });
+    });
+    </script>
+</body>
+</html>

--- a/blog9.html
+++ b/blog9.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+    <title>Optionsgriechen verständlich erklärt: Delta, Gamma, Theta und Vega</title>
+    <meta name="description" content="Verstehen Sie die wichtigsten Optionsgriechen und treffen Sie bessere Handelsentscheidungen.">
+    <link rel="icon" href="Favicon.jpg" type="image/jpeg">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <nav>
+            <div class="nav-container">
+                <div class="logo">
+                    <a href="index.html"><img src="Logo.jpg" alt="Just Options Logo"></a>
+                </div>
+                <div id="mobileMenuToggle" class="mobile-menu">
+                    <i class="fas fa-bars"></i>
+                </div>
+                <ul id="navLinks" class="nav-links">
+                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
+
+    <section class="page-title">
+        <div class="container">
+            <h1>Optionsgriechen verständlich erklärt</h1>
+            <p>Die wichtigsten Kennzahlen für Optionshändler im Überblick.</p>
+        </div>
+    </section>
+
+    <section>
+        <div class="container">
+            <div class="blog-content">
+                <h2>Optionsgriechen verständlich erklärt: Delta, Gamma, Theta und Vega</h2>
+                <p>Die Optionsgriechen messen die Sensitivität einer Option gegenüber verschiedenen Einflussfaktoren. Wer sie versteht, kann Risiken besser steuern und Chancen gezielt nutzen.</p>
+
+                <h3>Delta verstehen</h3>
+                <p>Delta gibt an, wie stark sich der Preis einer Option bei einer Kursänderung des Basiswerts bewegt. Ein Delta von 0,5 bedeutet, dass die Option um 0,50 Euro steigt, wenn der Basiswert um 1 Euro steigt.</p>
+
+                <h3>Gamma und seine Bedeutung</h3>
+                <p>Gamma zeigt an, wie sich das Delta verändert. Hohe Gamma-Werte weisen auf eine starke Kursreaktion hin, insbesondere bei At-the-money-Optionen kurz vor dem Verfall.</p>
+
+                <h3>Theta und Vega im Blick</h3>
+                <p>Theta beschreibt den Zeitwertverfall einer Option, während Vega die Empfindlichkeit gegenüber Änderungen der Volatilität misst. Beide Größen sind entscheidend für Stillhalterstrategien.</p>
+
+                <h3>Fazit</h3>
+                <p>Die Optionsgriechen sind unverzichtbare Werkzeuge für fundierte Handelsentscheidungen. Eine vertiefte Erläuterung finden Sie in <a href="index.html#book">meinem Buch</a>.</p>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-content">
+                <div class="logo-container">
+                    <img src="Logo.jpg" alt="Just Options Logo - Optionen strategisch nutzen" style="max-width: 120px; height: auto;" loading="lazy">
+                </div>
+                <ul class="footer-links">
+                    <li><a href="index.html#book">Das Buch</a></li>
+                    <li><a href="index.html#author">Autor</a></li>
+                    <li><a href="index.html#reviews">Rezensionen</a></li>
+                    <li><a href="index.html#faq">FAQ</a></li>
+                    <li><a href="impressum.html" target="_blank" rel="noopener">Impressum</a></li>
+                    <li><a href="datenschutz.html" target="_blank" rel="noopener">Datenschutz</a></li>
+                </ul>
+            </div>
+            <div class="social-icons">
+                <a href="https://www.linkedin.com/in/lehleiter/" target="_blank" rel="noopener"><i class="fab fa-linkedin"></i></a>
+                <a href="https://www.instagram.com/just_options.de/" target="_blank" rel="noopener"><i class="fab fa-instagram"></i></a>
+                <a href="https://t.me/just_options_com" target="_blank" rel="noopener"><i class="fab fa-telegram"></i></a>
+            </div>
+            <div class="copyright">
+                &copy; 2025 Lehleiter Investment Training. Alle Rechte vorbehalten.
+            </div>
+        </div>
+    </footer>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const mobileMenuToggle = document.getElementById('mobileMenuToggle');
+        const navLinks = document.getElementById('navLinks');
+
+        mobileMenuToggle.addEventListener('click', function() {
+            navLinks.classList.toggle('show');
+            document.body.style.overflow = navLinks.classList.contains('show') ? 'hidden' : 'auto';
+
+            const icon = mobileMenuToggle.querySelector('i');
+            if (navLinks.classList.contains('show')) {
+                icon.classList.remove('fa-bars');
+                icon.classList.add('fa-times');
+            } else {
+                icon.classList.remove('fa-times');
+                icon.classList.add('fa-bars');
+            }
+        });
+
+        const navLinkItems = navLinks.querySelectorAll('a');
+        navLinkItems.forEach(link => {
+            link.addEventListener('click', function() {
+                if (window.innerWidth <= 768) {
+                    navLinks.classList.remove('show');
+                    document.body.style.overflow = 'auto';
+                    const icon = mobileMenuToggle.querySelector('i');
+                    icon.classList.remove('fa-times');
+                    icon.classList.add('fa-bars');
+                }
+            });
+        });
+    });
+    </script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,590 @@
+        :root {
+            --primary: #003366;
+            --secondary: #7e97c3;
+            --accent: #ffd700;
+            --light: #ffffff;
+            --dark: #333333;
+            --success: #66cc99;
+            --text-gray: #555555;
+            --black: #000000;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+            max-width: 100%;
+        }
+
+        html {
+            font-size: 16px;
+            font-size: calc(14px + 0.25vw);
+        }
+
+        body {
+            font-family: 'Roboto', sans-serif;
+            line-height: 1.6;
+            color: var(--dark);
+            background-color: var(--light);
+            -webkit-text-size-adjust: 100%;
+            -webkit-font-smoothing: antialiased;
+            font-size: 1rem;
+            overflow-x: hidden;
+            width: 100%;
+        }
+
+        h1 {
+            font-size: clamp(2rem, 4vw + 1rem, 3.5rem);
+            line-height: 1.2;
+        }
+
+        h2 {
+            font-size: clamp(1.8rem, 3vw + 0.5rem, 2.8rem);
+            line-height: 1.2;
+        }
+
+        h3 {
+            font-size: clamp(1.2rem, 2vw + 0.3rem, 1.8rem);
+            line-height: 1.3;
+        }
+
+        p {
+            font-size: clamp(0.9rem, 1vw + 0.5rem, 1.1rem);
+        }
+
+        header {
+            background-color: var(--primary);
+            color: white;
+            padding: 1rem;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        }
+
+        nav {
+            width: 100%;
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .nav-container {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            flex-wrap: wrap;
+            padding: 0 20px;
+        }
+
+        .logo {
+            font-size: 1.5rem;
+            font-weight: bold;
+            display: flex;
+            align-items: center;
+        }
+
+        .logo img {
+            height: 50px;
+            max-width: 100%;
+        }
+
+        .nav-links {
+            display: flex;
+            list-style: none;
+            justify-content: flex-end;
+            margin: 0;
+            padding: 0;
+        }
+
+        .nav-links li {
+            margin: 0 0 0 2rem;
+        }
+
+        .nav-links a {
+            color: white;
+            text-decoration: none;
+            transition: color 0.3s;
+            padding: 0.5rem 0;
+            display: block;
+            white-space: nowrap;
+        }
+
+        .nav-links a:hover {
+            color: var(--accent);
+        }
+
+        .mobile-menu-toggle {
+            display: none;
+            font-size: 1.5rem;
+            color: white;
+            background: transparent;
+            border: none;
+            cursor: pointer;
+            padding: 0.5rem;
+            z-index: 110;
+        }
+
+        .mobile-menu-toggle:focus {
+            outline: none;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 20px;
+            width: 100%;
+            overflow: hidden;
+        }
+
+        .page-title {
+            background: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url('/api/placeholder/1200/300') center/cover no-repeat;
+            color: white;
+            text-align: center;
+            padding: 3rem 1rem;
+            border-top: none;
+            background-color: #333333;
+        }
+
+        .page-title h1 {
+            margin-bottom: 1rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+            line-height: 1.2;
+            max-width: 90%;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .page-title p {
+            font-size: 1.2rem;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 10px;
+        }
+
+        section {
+            padding: 5rem 0;
+            border-top: 1px solid rgba(0, 0, 0, 0.05);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+            position: relative;
+        }
+
+        section:nth-child(odd) {
+            background-color: var(--light);
+        }
+
+        section:nth-child(even) {
+            background-color: #e2e2e3;
+        }
+
+        section h2 {
+            text-align: center;
+            margin-bottom: 3rem;
+            color: var(--primary);
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            line-height: 1.2;
+        }
+
+        .blog-content {
+            padding: 2rem;
+            background-color: white;
+            border-radius: 10px;
+            box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+            margin-bottom: 2rem;
+        }
+
+        .blog-content h2 {
+            color: var(--primary);
+            margin-bottom: 1rem;
+        }
+
+        .blog-content h3 {
+            color: var(--secondary);
+            margin-bottom: 1rem;
+        }
+
+        .blog-content p {
+            color: var(--text-gray);
+            margin-bottom: 1rem;
+        }
+
+        .blog-content ul {
+            list-style-position: inside;
+            padding-left: 0;
+            margin-bottom: 1rem;
+            color: var(--text-gray);
+        }
+
+        .blog-content li {
+            margin-bottom: 0.5rem;
+        }
+
+        .blog-content strong {
+            color: var(--primary);
+        }
+
+        .blog-content a {
+            color: var(--accent);
+            text-decoration: none;
+            font-weight: bold;
+        }
+
+        .blog-content a:hover {
+            text-decoration: underline;
+        }
+
+        footer {
+            background-color: var(--primary);
+            color: white;
+            padding: 3rem 0;
+            text-align: center;
+            border-top: none;
+        }
+
+        .footer-content {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-bottom: 1.5rem;
+        }
+
+        .logo-container {
+            display: flex;
+            align-items: center;
+            margin-right: 2rem;
+        }
+
+        .footer-links {
+            display: flex;
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            flex-wrap: wrap;
+            justify-content: center;
+        }
+
+        .footer-links li {
+            margin: 0 1rem;
+        }
+
+        .footer-links a {
+            color: white;
+            text-decoration: none;
+            padding: 0.25rem 0;
+            display: inline-block;
+        }
+
+        .footer-links a:hover {
+            text-decoration: underline;
+        }
+
+        .social-icons {
+            margin: 1rem 0;
+        }
+
+        .social-icons a {
+            color: white;
+            margin: 0 0.8rem;
+            font-size: 1.8rem;
+            transition: color 0.3s ease;
+            display: inline-block;
+            padding: 0.5rem;
+        }
+
+        .social-icons a:hover {
+            color: var(--accent);
+        }
+
+        .copyright {
+            font-size: 0.9rem;
+            margin-top: 2rem;
+        }
+
+       @media screen and (max-width: 992px) {
+            .container {
+                width: 90%;
+            }
+
+            h1 {
+                font-size: clamp(1.8rem, 3vw + 1rem, 3rem);
+            }
+
+            h2 {
+                font-size: clamp(1.6rem, 2.5vw + 0.5rem, 2.5rem);
+            }
+
+            h3 {
+                font-size: clamp(1.1rem, 1.5vw + 0.3rem, 1.5rem);
+            }
+        }
+
+        @media screen and (max-width: 768px) {
+            .mobile-menu-toggle {
+                display: block;
+            }
+
+            .nav-container {
+                justify-content: center;
+                text-align: center;
+            }
+
+            .logo {
+                margin: 0 auto;
+                padding: 0.5rem 0;
+            }
+
+            .nav-links {
+                display: none;
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100vh;
+                background-color: var(--primary);
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                z-index: 100;
+                padding: 2rem;
+            }
+
+            .nav-links.show {
+                display: flex;
+            }
+
+            .nav-links li {
+                margin: 1rem 0;
+            }
+
+            .nav-links a {
+                font-size: 1.2rem;
+                padding: 0.5rem 0;
+            }
+
+            .mobile-menu-toggle {
+                position: absolute;
+                top: 1.5rem;
+                right: 2rem;
+            }
+        }
+
+        @media screen and (max-width: 480px) {
+            .page-title {
+                padding: 2.5rem 1rem;
+            }
+
+            .page-title h1 {
+                font-size: 2rem;
+            }
+
+            .page-title p {
+                font-size: 1rem;
+            }
+
+            .btn {
+                padding: 0.7rem 1.4rem;
+                font-size: 0.9rem;
+            }
+        }
+        
+        /* Zusätzliche Stile für den erweiterten Artikel */
+        
+        .table-of-contents {
+            background-color: #f5f5f5;
+            padding: 1.5rem;
+            border-radius: 8px;
+            margin-bottom: 2rem;
+        }
+        
+        .table-of-contents h3 {
+            margin-bottom: 0.8rem;
+        }
+        
+        .table-of-contents ol {
+            list-style-position: inside;
+            padding-left: 1rem;
+        }
+        
+        .table-of-contents li {
+            margin-bottom: 0.5rem;
+        }
+        
+        .table-of-contents a {
+            color: var(--primary);
+            text-decoration: none;
+        }
+        
+        .table-of-contents a:hover {
+            text-decoration: underline;
+        }
+        
+        .strategy-box {
+            border: 1px solid #e2e2e3;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+            border-radius: 8px;
+            background-color: #f9f9f9;
+        }
+        
+        .strategy-box h4 {
+            color: var(--primary);
+            font-size: 1.2rem;
+            margin-bottom: 0.8rem;
+            border-bottom: 2px solid var(--accent);
+            padding-bottom: 0.5rem;
+            display: inline-block;
+        }
+        
+        .example-box {
+            background-color: rgba(126, 151, 195, 0.1);
+            border-left: 3px solid var(--secondary);
+            padding: 1rem;
+            margin: 1rem 0;
+            border-radius: 5px;
+        }
+        
+        .tip-box {
+            background-color: rgba(102, 204, 153, 0.1);
+            border-left: 3px solid var(--success);
+            padding: 1rem;
+            margin: 1rem 0;
+            border-radius: 5px;
+        }
+        
+        .warning-box {
+            background-color: rgba(255, 99, 71, 0.1);
+            border-left: 3px solid tomato;
+            padding: 1rem;
+            margin: 1rem 0;
+            border-radius: 5px;
+        }
+        
+        .comparison-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1.5rem 0;
+        }
+        
+        .comparison-table th, .comparison-table td {
+            border: 1px solid #ddd;
+            padding: 0.8rem;
+            text-align: left;
+        }
+        
+        .comparison-table th {
+            background-color: var(--primary);
+            color: white;
+        }
+        
+        .comparison-table tr:nth-child(even) {
+            background-color: #f2f2f2;
+        }
+        
+        .key-term {
+            font-weight: 600;
+            color: var(--primary);
+            border-bottom: 1px dotted var(--secondary);
+            cursor: help;
+        }
+        
+        .chart-placeholder {
+            background-color: #f5f5f5;
+            border: 1px dashed #ccc;
+            border-radius: 8px;
+            height: 250px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 1.5rem 0;
+            color: var(--text-gray);
+        }
+        
+        .cta-box {
+            background-color: rgba(0, 51, 102, 0.05);
+            border: 1px solid var(--primary);
+            padding: 1.5rem;
+            text-align: center;
+            margin: 2rem 0;
+            border-radius: 8px;
+        }
+        
+        .cta-box h3 {
+            margin-bottom: 1rem;
+        }
+        
+        .cta-box .btn {
+            display: inline-block;
+            background-color: var(--primary);
+            color: white;
+            padding: 0.8rem 1.5rem;
+            border-radius: 4px;
+            text-decoration: none;
+            font-weight: 600;
+            transition: background-color 0.3s;
+            margin-top: 1rem;
+        }
+        
+        .cta-box .btn:hover {
+            background-color: #002244;
+            text-decoration: none;
+        }
+        
+        .highlight-text {
+            font-weight: 500;
+            background-color: rgba(255, 215, 0, 0.2);
+            padding: 0 0.3rem;
+        }
+
+        .score-box {
+            background-color: rgba(0, 51, 102, 0.05);
+            border: 2px solid var(--primary);
+            border-radius: 8px;
+            padding: 2rem;
+            margin: 2rem 0;
+            text-align: center;
+        }
+
+        .score-number {
+            font-size: 3rem;
+            font-weight: 700;
+            color: var(--primary);
+            display: block;
+            margin-bottom: 0.5rem;
+        }
+
+        .score-label {
+            font-size: 1.2rem;
+            color: var(--secondary);
+        }
+
+        .metrics-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 1.5rem;
+            margin: 2rem 0;
+        }
+
+        .metric-card {
+            background-color: #f8f8f8;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            padding: 1.5rem;
+            text-align: center;
+        }
+
+        .metric-value {
+            font-size: 2rem;
+            font-weight: 700;
+            color: var(--primary);
+            display: block;
+            margin-bottom: 0.5rem;
+        }
+
+        .metric-label {
+            font-size: 0.9rem;
+            color: var(--text-gray);
+        }


### PR DESCRIPTION
## Summary
- add 10 new SEO-optimized blog posts on options trading topics
- factor out common styling into `style.css`
- update `blog.html` to list the new articles

## Testing
- `npm test` (fails: package.json missing)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fa82c02348332841ae04f744e1297