### PR TITLE
Standardize blog articles and add disclaimer

### DIFF
--- a/blog1.html
+++ b/blog1.html
@@ -499,6 +499,56 @@
             border-bottom: 1px dotted var(--secondary);
             cursor: help;
         }
+    
+        .cta-box {
+            background-color: rgba(0, 51, 102, 0.05);
+            border: 1px solid var(--primary);
+            padding: 1.5rem;
+            text-align: center;
+            margin: 2rem 0;
+            border-radius: 8px;
+        }
+
+        .cta-box h3 {
+            margin-bottom: 1rem;
+        }
+
+        .cta-box .btn {
+            display: inline-block;
+            background-color: var(--primary);
+            color: white;
+            padding: 0.8rem 1.5rem;
+            border-radius: 4px;
+            text-decoration: none;
+            font-weight: 600;
+            transition: background-color 0.3s;
+            margin-top: 1rem;
+        }
+
+        .cta-box .btn:hover {
+            background-color: #002244;
+            text-decoration: none;
+        }
+
+        .author-box {
+            background-color: rgba(0, 51, 102, 0.05);
+            border-left: 4px solid var(--secondary);
+            padding: 1rem 1.5rem;
+            margin: 2rem 0;
+            border-radius: 8px;
+        }
+
+        .author-box h3 {
+            color: var(--secondary);
+            margin-bottom: 0.5rem;
+        }
+
+        .disclaimer {
+            font-size: 0.9rem;
+            color: var(--text-gray);
+            margin-top: 2rem;
+        }
+
     </style>
 </head>
 <body>
@@ -855,7 +905,20 @@
                 
                 <p>Der Schlüssel zum Erfolg liegt in gründlicher Bildung, konsequentem Risikomanagement und der Auswahl der richtigen Strategie für die jeweilige Marktlage. Starten Sie klein, lernen Sie kontinuierlich dazu und bauen Sie Ihre Fähigkeiten schrittweise aus.</p>
                 
-                <p>Möchten Sie tiefer in die Welt des Optionshandels eintauchen? <a href="index.html#book">Mein Buch</a> bietet einen umfassenden Einstieg und fortgeschrittene Strategien für ambitionierte Anleger.</p>
+            
+                <div class="cta-box">
+                    <h3>Möchten Sie Ihr Wissen im Optionshandel vertiefen?</h3>
+                    <p>In meinem Buch <em>"Optionen strategisch nutzen"</em> finden Sie detaillierte Anleitungen, fortgeschrittene Strategien und praxiserprobte Techniken, die Ihnen helfen, den Optionshandel sicher und erfolgreich zu meistern.</p>
+                    <a href="index.html#book" class="btn">Mehr über das Buch erfahren</a>
+                </div>
+
+                <div class="author-box">
+                    <h3>Über den Autor</h3>
+                    <p>Markus Lehleiter, CFA ist Experte für strategischen Optionshandel mit über zwei Jahrzehnten Erfahrung an den Finanzmärkten. Als Gründer von Lehleiter Investment Training vermittelt er konservative, erprobte Optionsstrategien an Privatanleger und institutionelle Investoren.</p>
+                </div>
+
+                <p class="disclaimer"><strong>Disclaimer:</strong> Dieser Artikel dient ausschließlich Informationszwecken und stellt keine Anlageberatung dar. Optionshandel birgt erhebliche Risiken bis hin zum Totalverlust. Konsultieren Sie einen qualifizierten Finanzberater vor Handelsentscheidungen.</p>
+
             </div>
         </div>
     </section>

--- a/blog10.html
+++ b/blog10.html
@@ -45,7 +45,7 @@
                     <i class="fas fa-bars"></i>
                 </div>
                 <ul id="navLinks" class="nav-links">
-                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="index.html#book">Das Buch</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="index.html#author">Autor</a></li>
                     <li><a href="index.html#reviews">Rezensionen</a></li>
@@ -154,11 +154,23 @@
                     <p>Diese Strategien ersetzen keine diversifizierte Vermögensanlage, sondern ergänzen sie sinnvoll. Mit der richtigen Vorbereitung, realistischen Erwartungen und disziplinierter Umsetzung können Sie Stillhalterstrategien erfolgreich in Ihr Portfolio integrieren.</p>
 
                     <div style="background-color: #f0f4f8; padding: 20px; border-radius: 8px; margin: 30px 0;">
-                        <p><strong>Möchten Sie Stillhalterstrategien professionell erlernen?</strong> In meinem <a href="index.html#book">umfassenden Praxisbuch</a> finden Sie detaillierte Schritt-für-Schritt-Anleitungen, konkrete Beispiele aus der Praxis, Backtesting-Ergebnisse und bewährte Systeme für den nachhaltigen Erfolg mit Optionen. Über 300 Seiten fundiertes Wissen für Ihren strategischen Vermögensaufbau.</p>
                     </div>
 
-                    <p style="font-size: 0.9em; color: #666; margin-top: 40px;"><em>Disclaimer: Dieser Artikel dient ausschließlich Informationszwecken und stellt keine Anlageberatung dar. Optionshandel birgt erhebliche Risiken bis hin zum Totalverlust. Konsultieren Sie einen qualifizierten Finanzberater vor Handelsentscheidungen.</em></p>
                 </article>
+            
+                <div class="cta-box">
+                    <h3>Möchten Sie Ihr Wissen im Optionshandel vertiefen?</h3>
+                    <p>In meinem Buch <em>"Optionen strategisch nutzen"</em> finden Sie detaillierte Anleitungen, fortgeschrittene Strategien und praxiserprobte Techniken, die Ihnen helfen, den Optionshandel sicher und erfolgreich zu meistern.</p>
+                    <a href="index.html#book" class="btn">Mehr über das Buch erfahren</a>
+                </div>
+
+                <div class="author-box">
+                    <h3>Über den Autor</h3>
+                    <p>Markus Lehleiter, CFA ist Experte für strategischen Optionshandel mit über zwei Jahrzehnten Erfahrung an den Finanzmärkten. Als Gründer von Lehleiter Investment Training vermittelt er konservative, erprobte Optionsstrategien an Privatanleger und institutionelle Investoren.</p>
+                </div>
+
+                <p class="disclaimer"><strong>Disclaimer:</strong> Dieser Artikel dient ausschließlich Informationszwecken und stellt keine Anlageberatung dar. Optionshandel birgt erhebliche Risiken bis hin zum Totalverlust. Konsultieren Sie einen qualifizierten Finanzberater vor Handelsentscheidungen.</p>
+
             </div>
         </div>
     </section>

--- a/blog11.html
+++ b/blog11.html
@@ -44,7 +44,7 @@ n<!DOCTYPE html>
                     <i class="fas fa-bars"></i>
                 </div>
                 <ul id="navLinks" class="nav-links">
-                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="index.html#book">Das Buch</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="index.html#author">Autor</a></li>
                     <li><a href="index.html#reviews">Rezensionen</a></li>
@@ -274,7 +274,6 @@ n<!DOCTYPE html>
 
                 <h2>Fazit: Steuerliche Kompetenz als Erfolgsfaktor</h2>
                 
-                <p>Die steuerliche Behandlung von Optionsgeschäften ist komplex, aber beherrschbar. Mit dem richtigen Wissen und einer sorgfältigen Dokumentation vermeiden Sie kostspielige Fehler und optimieren Ihre Nach-Steuer-Rendite. Wie im <a href="index.html#book">Buch "Just Options"</a> ausführlich dargelegt, gehört das Verständnis der steuerlichen Rahmenbedingungen zu den Grundlagen eines erfolgreichen Optionshandels.</p>
 
                 <p><strong>Drei Kernpunkte für Ihren Erfolg:</strong></p>
                 <ol>
@@ -287,12 +286,24 @@ n<!DOCTYPE html>
 
                 <div class="cta-box" style="background-color: #f0f8ff; padding: 20px; margin: 30px 0; border-left: 4px solid #0066cc;">
                     <h3>Vertiefen Sie Ihr Wissen</h3>
-                    <p>Möchten Sie mehr über professionelle Optionsstrategien und deren steueroptimale Umsetzung erfahren? In meinem <a href="index.html#book"><strong>umfassenden Praxisbuch</strong></a> finden Sie detaillierte Anleitungen, Checklisten und Beispiele für Ihren erfolgreichen Start in den Optionshandel.</p>
                 </div>
 
                 <p class="disclaimer" style="font-size: 0.9em; color: #666; margin-top: 30px; padding-top: 20px; border-top: 1px solid #ddd;">
-                <strong>Disclaimer:</strong> Dieser Artikel stellt keine Steuerberatung dar und ersetzt nicht die individuelle Beratung durch einen Steuerberater oder Wirtschaftsprüfer. Die steuerliche Behandlung hängt von den persönlichen Verhältnissen ab und kann künftigen Änderungen unterworfen sein. Stand: Dezember 2024 (unter Berücksichtigung des Jahressteuergesetzes 2024).
                 </p>
+            
+                <div class="cta-box">
+                    <h3>Möchten Sie Ihr Wissen im Optionshandel vertiefen?</h3>
+                    <p>In meinem Buch <em>"Optionen strategisch nutzen"</em> finden Sie detaillierte Anleitungen, fortgeschrittene Strategien und praxiserprobte Techniken, die Ihnen helfen, den Optionshandel sicher und erfolgreich zu meistern.</p>
+                    <a href="index.html#book" class="btn">Mehr über das Buch erfahren</a>
+                </div>
+
+                <div class="author-box">
+                    <h3>Über den Autor</h3>
+                    <p>Markus Lehleiter, CFA ist Experte für strategischen Optionshandel mit über zwei Jahrzehnten Erfahrung an den Finanzmärkten. Als Gründer von Lehleiter Investment Training vermittelt er konservative, erprobte Optionsstrategien an Privatanleger und institutionelle Investoren.</p>
+                </div>
+
+                <p class="disclaimer"><strong>Disclaimer:</strong> Dieser Artikel dient ausschließlich Informationszwecken und stellt keine Anlageberatung dar. Optionshandel birgt erhebliche Risiken bis hin zum Totalverlust. Konsultieren Sie einen qualifizierten Finanzberater vor Handelsentscheidungen.</p>
+
             </div>
         </div>
     </section>

--- a/blog12.html
+++ b/blog12.html
@@ -41,7 +41,7 @@
                     <i class="fas fa-bars"></i>
                 </div>
                 <ul id="navLinks" class="nav-links">
-                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="index.html#book">Das Buch</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="index.html#author">Autor</a></li>
                     <li><a href="index.html#reviews">Rezensionen</a></li>
@@ -460,7 +460,6 @@
                 </div>
 
                 <p><strong>Bereit, Ihr Options-Trading auf das nächste Level zu heben?</strong></p>
-                <p>In meinem Buch <a href="index.html#book"><strong>"Just Options: Erfolgreich handeln mit System"</strong></a> finden Sie eine umfassende Anleitung zu über 20 bewährten Optionsstrategien – von Einsteiger-Strategien wie Cash Secured Puts bis zu fortgeschrittenen Konzepten wie Calendar Spreads und LEAPS. Mit detaillierten Praxisbeispielen, professionellem Risikomanagement und einem systematischen Ansatz für nachhaltigen Erfolg.</p>
                 
                 <p>Das Buch bietet Ihnen:</p>
                 <ul style="list-style-type: disc; margin-left: 20px;">
@@ -471,7 +470,20 @@
                     <li>Praktische Tools und Ressourcen</li>
                 </ul>
                 
-                <p><a href="index.html#book" style="display: inline-block; background-color: #0066cc; color: white; padding: 12px 24px; text-decoration: none; border-radius: 5px; margin-top: 20px;">→ Jetzt "Just Options" entdecken</a></p>
+            
+                <div class="cta-box">
+                    <h3>Möchten Sie Ihr Wissen im Optionshandel vertiefen?</h3>
+                    <p>In meinem Buch <em>"Optionen strategisch nutzen"</em> finden Sie detaillierte Anleitungen, fortgeschrittene Strategien und praxiserprobte Techniken, die Ihnen helfen, den Optionshandel sicher und erfolgreich zu meistern.</p>
+                    <a href="index.html#book" class="btn">Mehr über das Buch erfahren</a>
+                </div>
+
+                <div class="author-box">
+                    <h3>Über den Autor</h3>
+                    <p>Markus Lehleiter, CFA ist Experte für strategischen Optionshandel mit über zwei Jahrzehnten Erfahrung an den Finanzmärkten. Als Gründer von Lehleiter Investment Training vermittelt er konservative, erprobte Optionsstrategien an Privatanleger und institutionelle Investoren.</p>
+                </div>
+
+                <p class="disclaimer"><strong>Disclaimer:</strong> Dieser Artikel dient ausschließlich Informationszwecken und stellt keine Anlageberatung dar. Optionshandel birgt erhebliche Risiken bis hin zum Totalverlust. Konsultieren Sie einen qualifizierten Finanzberater vor Handelsentscheidungen.</p>
+
             </div>
         </div>
     </section>

--- a/blog13.html
+++ b/blog13.html
@@ -41,7 +41,7 @@
                     <i class="fas fa-bars"></i>
                 </div>
                 <ul id="navLinks" class="nav-links">
-                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="index.html#book">Das Buch</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="index.html#author">Autor</a></li>
                     <li><a href="index.html#reviews">Rezensionen</a></li>
@@ -422,11 +422,23 @@
                     </ol>
                 </div>
 
-                <p style="margin-top: 30px;"><strong>Vertiefen Sie Ihr Wissen:</strong> In meinem Buch <a href="index.html#book">"Just Options: Optionen strategisch nutzen"</a> finden Sie detaillierte Fallstudien aus meiner über 10-jährigen Trading-Erfahrung, Excel-Vorlagen für die Positionsgrößenberechnung und bewährte Checklisten für verschiedene Marktphasen. Lernen Sie, wie Sie ein robustes System für nachhaltigen Erfolg im Optionshandel aufbauen.</p>
 
                 <div style="background-color: #f0f8ff; padding: 20px; border-radius: 8px; margin-top: 30px;">
-                    <p><em><strong>Disclaimer:</strong> Dieser Artikel dient ausschließlich Bildungszwecken. Options-Trading birgt erhebliche Risiken und ist nicht für jeden Anleger geeignet. Die vorgestellten Strategien stellen keine Anlageberatung dar. Konsultieren Sie einen qualifizierten Finanzberater, bevor Sie Handelsentscheidungen treffen.</em></p>
                 </div>
+            
+                <div class="cta-box">
+                    <h3>Möchten Sie Ihr Wissen im Optionshandel vertiefen?</h3>
+                    <p>In meinem Buch <em>"Optionen strategisch nutzen"</em> finden Sie detaillierte Anleitungen, fortgeschrittene Strategien und praxiserprobte Techniken, die Ihnen helfen, den Optionshandel sicher und erfolgreich zu meistern.</p>
+                    <a href="index.html#book" class="btn">Mehr über das Buch erfahren</a>
+                </div>
+
+                <div class="author-box">
+                    <h3>Über den Autor</h3>
+                    <p>Markus Lehleiter, CFA ist Experte für strategischen Optionshandel mit über zwei Jahrzehnten Erfahrung an den Finanzmärkten. Als Gründer von Lehleiter Investment Training vermittelt er konservative, erprobte Optionsstrategien an Privatanleger und institutionelle Investoren.</p>
+                </div>
+
+                <p class="disclaimer"><strong>Disclaimer:</strong> Dieser Artikel dient ausschließlich Informationszwecken und stellt keine Anlageberatung dar. Optionshandel birgt erhebliche Risiken bis hin zum Totalverlust. Konsultieren Sie einen qualifizierten Finanzberater vor Handelsentscheidungen.</p>
+
             </div>
         </div>
     </section>

--- a/blog14.html
+++ b/blog14.html
@@ -42,7 +42,7 @@
                     <i class="fas fa-bars"></i>
                 </div>
                 <ul id="navLinks" class="nav-links">
-                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="index.html#book">Das Buch</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="index.html#author">Autor</a></li>
                     <li><a href="index.html#reviews">Rezensionen</a></li>
@@ -162,7 +162,6 @@
 
                 <div class="cta-box" style="background-color: #f0f8ff; padding: 20px; border-left: 4px solid #2c5aa0; margin: 30px 0;">
                     <h3>Vertiefen Sie Ihr Wissen</h3>
-                    <p>Möchten Sie die hier vorgestellten Strategien im Detail verstehen und professionell umsetzen? In meinem Buch <a href="index.html#book"><strong>"Optionen strategisch nutzen"</strong></a> finden Sie auf über 200 Seiten:</p>
                     <ul>
                         <li>Schritt-für-Schritt-Anleitungen für alle wichtigen Optionsstrategien</li>
                         <li>Konkrete Beispiele aus der Praxis mit realen Trades</li>
@@ -170,12 +169,24 @@
                         <li>Backtesting-Ergebnisse bewährter Strategien</li>
                         <li>Aufbau eines systematischen Trading-Systems</li>
                     </ul>
-                    <p><a href="index.html#book" class="button" style="display: inline-block; padding: 10px 20px; background-color: #2c5aa0; color: white; text-decoration: none; border-radius: 5px;">Zum Buch →</a></p>
                 </div>
 
                 <div class="author-info" style="background-color: #f9f9f9; padding: 20px; border-radius: 8px; margin-top: 30px;">
-                    <p><em>Über den Autor: Markus Lehleiter ist Experte für strategischen Optionshandel mit über zwei Jahrzehnten Erfahrung an den Finanzmärkten. Als Gründer von Lehleiter Investment Training vermittelt er konservative, erprobte Optionsstrategien an Privatanleger und institutionelle Investoren.</em></p>
                 </div>
+            
+                <div class="cta-box">
+                    <h3>Möchten Sie Ihr Wissen im Optionshandel vertiefen?</h3>
+                    <p>In meinem Buch <em>"Optionen strategisch nutzen"</em> finden Sie detaillierte Anleitungen, fortgeschrittene Strategien und praxiserprobte Techniken, die Ihnen helfen, den Optionshandel sicher und erfolgreich zu meistern.</p>
+                    <a href="index.html#book" class="btn">Mehr über das Buch erfahren</a>
+                </div>
+
+                <div class="author-box">
+                    <h3>Über den Autor</h3>
+                    <p>Markus Lehleiter, CFA ist Experte für strategischen Optionshandel mit über zwei Jahrzehnten Erfahrung an den Finanzmärkten. Als Gründer von Lehleiter Investment Training vermittelt er konservative, erprobte Optionsstrategien an Privatanleger und institutionelle Investoren.</p>
+                </div>
+
+                <p class="disclaimer"><strong>Disclaimer:</strong> Dieser Artikel dient ausschließlich Informationszwecken und stellt keine Anlageberatung dar. Optionshandel birgt erhebliche Risiken bis hin zum Totalverlust. Konsultieren Sie einen qualifizierten Finanzberater vor Handelsentscheidungen.</p>
+
             </div>
         </div>
     </section>

--- a/blog15.html
+++ b/blog15.html
@@ -46,7 +46,7 @@
                     <i class="fas fa-bars"></i>
                 </div>
                 <ul id="navLinks" class="nav-links">
-                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="index.html#book">Das Buch</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="index.html#author">Autor</a></li>
                     <li><a href="index.html#reviews">Rezensionen</a></li>
@@ -248,11 +248,9 @@
                     <li>Ein zweites Standbein neben Ihrem regulären Einkommen aufbauen</li>
                 </ul>
 
-                <p><strong>Der wichtigste Schritt ist der erste:</strong> Beginnen Sie mit Ihrer Ausbildung, eröffnen Sie ein Demo-Konto und sammeln Sie erste Erfahrungen. Der Optionshandel ist kein Sprint, sondern ein Marathon – mit der richtigen Vorbereitung und Geduld werden Sie erfolgreich sein.</p>
-
-                <div class="cta-box" style="background-color: #f0f8ff; padding: 20px; border-left: 4px solid #0066cc; margin: 30px 0;">
+                <p><strong>Der wichtigste Schritt ist der erste:</strong> Beginnen Sie mit Ihrer Ausbildung, eröffnen Sie ein Demo-Konto und sammeln Sie erste Erfahrungen. Der Optionshandel ist kein Sprint, sondern ein Marathon – mit der richtigen Vorbereitung und Geduld werden Sie erfolgreich sein.</p>f0f8ff;.*?</div>
+#f0f8ff; padding: 20px; border-left: 4px solid #0066cc; margin: 30px 0;">
                     <h3>Bereit für den nächsten Schritt?</h3>
-                    <p>In meinem umfassenden Buch <strong>"Just Options – Optionen strategisch nutzen"</strong> finden Sie:</p>
                     <ul>
                         <li>Detaillierte Anleitungen zu allen vorgestellten Strategien</li>
                         <li>Fortgeschrittene Techniken für wachsende Portfolios</li>
@@ -260,10 +258,20 @@
                         <li>Professionelle Risikomanagement-Systeme</li>
                         <li>Schritt-für-Schritt-Handelspläne und Checklisten</li>
                     </ul>
-                    <p><a href="index.html#book" style="color: #0066cc; font-weight: bold;">→ Mehr über das Buch erfahren</a></p>
+                </div>            
+                <div class="cta-box">
+                    <h3>Möchten Sie Ihr Wissen im Optionshandel vertiefen?</h3>
+                    <p>In meinem Buch <em>"Optionen strategisch nutzen"</em> finden Sie detaillierte Anleitungen, fortgeschrittene Strategien und praxiserprobte Techniken, die Ihnen helfen, den Optionshandel sicher und erfolgreich zu meistern.</p>
+                    <a href="index.html#book" class="btn">Mehr über das Buch erfahren</a>
                 </div>
 
-                <p><em>Disclaimer: Dieser Artikel dient ausschließlich Bildungszwecken. Optionshandel birgt erhebliche Risiken und ist nicht für jeden Anleger geeignet. Konsultieren Sie einen qualifizierten Finanzberater, bevor Sie Investitionsentscheidungen treffen.</em></p>
+                <div class="author-box">
+                    <h3>Über den Autor</h3>
+                    <p>Markus Lehleiter, CFA ist Experte für strategischen Optionshandel mit über zwei Jahrzehnten Erfahrung an den Finanzmärkten. Als Gründer von Lehleiter Investment Training vermittelt er konservative, erprobte Optionsstrategien an Privatanleger und institutionelle Investoren.</p>
+                </div>
+
+                <p class="disclaimer"><strong>Disclaimer:</strong> Dieser Artikel dient ausschließlich Informationszwecken und stellt keine Anlageberatung dar. Optionshandel birgt erhebliche Risiken bis hin zum Totalverlust. Konsultieren Sie einen qualifizierten Finanzberater vor Handelsentscheidungen.</p>
+
             </div>
         </div>
     </section>

--- a/blog16.html
+++ b/blog16.html
@@ -44,7 +44,7 @@
                     <i class="fas fa-bars"></i>
                 </div>
                 <ul id="navLinks" class="nav-links">
-                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="index.html#book">Das Buch</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="index.html#author">Autor</a></li>
                     <li><a href="index.html#reviews">Rezensionen</a></li>
@@ -142,10 +142,22 @@
                 <p>Beginnen Sie mit einfachen Strategien wie Cash Secured Puts oder Covered Calls an technischen Unterstützungen und Widerständen. Mit zunehmender Erfahrung können Sie komplexere Strategien wie Spreads und marktneutrale Ansätze integrieren.</p>
 
                 <div style="background-color: #f5f5f5; padding: 20px; border-left: 4px solid #333; margin: 30px 0;">
-                    <p><strong>Möchten Sie tiefer in die Materie einsteigen?</strong> In <a href="index.html#book" style="font-weight: bold;">meinem Buch "Just Options"</a> finden Sie detaillierte Praxisbeispiele, bewährte Strategien erfolgreicher Investoren und ein komplettes System für den professionellen Optionshandel – von den Grundlagen bis zum fortgeschrittenen Risikomanagement.</p>
                 </div>
 
-                <p><em>Disclaimer: Dieser Artikel dient ausschließlich Bildungszwecken. Optionshandel birgt erhebliche Risiken und ist nicht für jeden Anleger geeignet. Konsultieren Sie einen qualifizierten Finanzberater, bevor Sie Investitionsentscheidungen treffen.</em></p>
+            
+                <div class="cta-box">
+                    <h3>Möchten Sie Ihr Wissen im Optionshandel vertiefen?</h3>
+                    <p>In meinem Buch <em>"Optionen strategisch nutzen"</em> finden Sie detaillierte Anleitungen, fortgeschrittene Strategien und praxiserprobte Techniken, die Ihnen helfen, den Optionshandel sicher und erfolgreich zu meistern.</p>
+                    <a href="index.html#book" class="btn">Mehr über das Buch erfahren</a>
+                </div>
+
+                <div class="author-box">
+                    <h3>Über den Autor</h3>
+                    <p>Markus Lehleiter, CFA ist Experte für strategischen Optionshandel mit über zwei Jahrzehnten Erfahrung an den Finanzmärkten. Als Gründer von Lehleiter Investment Training vermittelt er konservative, erprobte Optionsstrategien an Privatanleger und institutionelle Investoren.</p>
+                </div>
+
+                <p class="disclaimer"><strong>Disclaimer:</strong> Dieser Artikel dient ausschließlich Informationszwecken und stellt keine Anlageberatung dar. Optionshandel birgt erhebliche Risiken bis hin zum Totalverlust. Konsultieren Sie einen qualifizierten Finanzberater vor Handelsentscheidungen.</p>
+
             </div>
         </div>
     </section>

--- a/blog2.html
+++ b/blog2.html
@@ -542,6 +542,56 @@
             border-bottom: 1px dotted var(--secondary);
             cursor: help;
         }
+    
+        .cta-box {
+            background-color: rgba(0, 51, 102, 0.05);
+            border: 1px solid var(--primary);
+            padding: 1.5rem;
+            text-align: center;
+            margin: 2rem 0;
+            border-radius: 8px;
+        }
+
+        .cta-box h3 {
+            margin-bottom: 1rem;
+        }
+
+        .cta-box .btn {
+            display: inline-block;
+            background-color: var(--primary);
+            color: white;
+            padding: 0.8rem 1.5rem;
+            border-radius: 4px;
+            text-decoration: none;
+            font-weight: 600;
+            transition: background-color 0.3s;
+            margin-top: 1rem;
+        }
+
+        .cta-box .btn:hover {
+            background-color: #002244;
+            text-decoration: none;
+        }
+
+        .author-box {
+            background-color: rgba(0, 51, 102, 0.05);
+            border-left: 4px solid var(--secondary);
+            padding: 1rem 1.5rem;
+            margin: 2rem 0;
+            border-radius: 8px;
+        }
+
+        .author-box h3 {
+            color: var(--secondary);
+            margin-bottom: 0.5rem;
+        }
+
+        .disclaimer {
+            font-size: 0.9rem;
+            color: var(--text-gray);
+            margin-top: 2rem;
+        }
+
     </style>
 </head>
 <body>
@@ -1007,12 +1057,19 @@
                 </ol>
                 
                 <p>Denken Sie daran: Der erfolgreichste Optionshändler ist nicht derjenige mit den komplexesten Strategien oder den spektakulärsten Gewinnen, sondern derjenige, der langfristig überlebt und kontinuierlich wächst – und das ist nur mit einem soliden Risikomanagement möglich.</p>
-                
                 <div class="cta-box">
-                    <h3>Möchten Sie Ihr Risikomanagement im Optionshandel auf das nächste Level heben?</h3>
-                    <p>In meinem Buch finden Sie detaillierte Anleitungen, fortgeschrittene Strategien und praxiserprobte Risikomanagement-Techniken, die Ihnen helfen, Ihr Kapital zu schützen und konstant profitabel zu handeln.</p>
+                    <h3>Möchten Sie Ihr Wissen im Optionshandel vertiefen?</h3>
+                    <p>In meinem Buch <em>"Optionen strategisch nutzen"</em> finden Sie detaillierte Anleitungen, fortgeschrittene Strategien und praxiserprobte Techniken, die Ihnen helfen, den Optionshandel sicher und erfolgreich zu meistern.</p>
                     <a href="index.html#book" class="btn">Mehr über das Buch erfahren</a>
                 </div>
+
+                <div class="author-box">
+                    <h3>Über den Autor</h3>
+                    <p>Markus Lehleiter, CFA ist Experte für strategischen Optionshandel mit über zwei Jahrzehnten Erfahrung an den Finanzmärkten. Als Gründer von Lehleiter Investment Training vermittelt er konservative, erprobte Optionsstrategien an Privatanleger und institutionelle Investoren.</p>
+                </div>
+
+                <p class="disclaimer"><strong>Disclaimer:</strong> Dieser Artikel dient ausschließlich Informationszwecken und stellt keine Anlageberatung dar. Optionshandel birgt erhebliche Risiken bis hin zum Totalverlust. Konsultieren Sie einen qualifizierten Finanzberater vor Handelsentscheidungen.</p>
+
             </div>
         </div>
     </section>

--- a/blog3.html
+++ b/blog3.html
@@ -555,6 +555,56 @@
             background-color: rgba(255, 215, 0, 0.2);
             padding: 0 0.3rem;
         }
+    
+        .cta-box {
+            background-color: rgba(0, 51, 102, 0.05);
+            border: 1px solid var(--primary);
+            padding: 1.5rem;
+            text-align: center;
+            margin: 2rem 0;
+            border-radius: 8px;
+        }
+
+        .cta-box h3 {
+            margin-bottom: 1rem;
+        }
+
+        .cta-box .btn {
+            display: inline-block;
+            background-color: var(--primary);
+            color: white;
+            padding: 0.8rem 1.5rem;
+            border-radius: 4px;
+            text-decoration: none;
+            font-weight: 600;
+            transition: background-color 0.3s;
+            margin-top: 1rem;
+        }
+
+        .cta-box .btn:hover {
+            background-color: #002244;
+            text-decoration: none;
+        }
+
+        .author-box {
+            background-color: rgba(0, 51, 102, 0.05);
+            border-left: 4px solid var(--secondary);
+            padding: 1rem 1.5rem;
+            margin: 2rem 0;
+            border-radius: 8px;
+        }
+
+        .author-box h3 {
+            color: var(--secondary);
+            margin-bottom: 0.5rem;
+        }
+
+        .disclaimer {
+            font-size: 0.9rem;
+            color: var(--text-gray);
+            margin-top: 2rem;
+        }
+
     </style>
 </head>
 <body>
@@ -1062,12 +1112,19 @@
                 </ul>
                 
                 <p>Der Volatilitätshandel erfordert Geduld, Disziplin und kontinuierliches Lernen. Doch für diejenigen, die bereit sind, diese Herausforderungen anzunehmen, bietet er eine der konsistentesten Renditequellen im Optionsmarkt – unabhängig davon, ob die Märkte steigen, fallen oder seitwärts tendieren.</p>
-                
                 <div class="cta-box">
-                    <h3>Möchten Sie Ihre Optionshandelsstrategien auf das nächste Level bringen?</h3>
-                    <p>In meinem Buch finden Sie detaillierte Anleitungen, Strategien und Techniken zum Volatilitätshandel und vielen weiteren Aspekten des erfolgreichen Optionshandels.</p>
+                    <h3>Möchten Sie Ihr Wissen im Optionshandel vertiefen?</h3>
+                    <p>In meinem Buch <em>"Optionen strategisch nutzen"</em> finden Sie detaillierte Anleitungen, fortgeschrittene Strategien und praxiserprobte Techniken, die Ihnen helfen, den Optionshandel sicher und erfolgreich zu meistern.</p>
                     <a href="index.html#book" class="btn">Mehr über das Buch erfahren</a>
                 </div>
+
+                <div class="author-box">
+                    <h3>Über den Autor</h3>
+                    <p>Markus Lehleiter, CFA ist Experte für strategischen Optionshandel mit über zwei Jahrzehnten Erfahrung an den Finanzmärkten. Als Gründer von Lehleiter Investment Training vermittelt er konservative, erprobte Optionsstrategien an Privatanleger und institutionelle Investoren.</p>
+                </div>
+
+                <p class="disclaimer"><strong>Disclaimer:</strong> Dieser Artikel dient ausschließlich Informationszwecken und stellt keine Anlageberatung dar. Optionshandel birgt erhebliche Risiken bis hin zum Totalverlust. Konsultieren Sie einen qualifizierten Finanzberater vor Handelsentscheidungen.</p>
+
             </div>
         </div>
     </section>

--- a/blog4.html
+++ b/blog4.html
@@ -605,6 +605,56 @@
             font-size: 0.9rem;
             color: var(--text-gray);
         }
+    
+        .cta-box {
+            background-color: rgba(0, 51, 102, 0.05);
+            border: 1px solid var(--primary);
+            padding: 1.5rem;
+            text-align: center;
+            margin: 2rem 0;
+            border-radius: 8px;
+        }
+
+        .cta-box h3 {
+            margin-bottom: 1rem;
+        }
+
+        .cta-box .btn {
+            display: inline-block;
+            background-color: var(--primary);
+            color: white;
+            padding: 0.8rem 1.5rem;
+            border-radius: 4px;
+            text-decoration: none;
+            font-weight: 600;
+            transition: background-color 0.3s;
+            margin-top: 1rem;
+        }
+
+        .cta-box .btn:hover {
+            background-color: #002244;
+            text-decoration: none;
+        }
+
+        .author-box {
+            background-color: rgba(0, 51, 102, 0.05);
+            border-left: 4px solid var(--secondary);
+            padding: 1rem 1.5rem;
+            margin: 2rem 0;
+            border-radius: 8px;
+        }
+
+        .author-box h3 {
+            color: var(--secondary);
+            margin-bottom: 0.5rem;
+        }
+
+        .disclaimer {
+            font-size: 0.9rem;
+            color: var(--text-gray);
+            margin-top: 2rem;
+        }
+
     </style>
 </head>
 <body>
@@ -887,12 +937,19 @@
                 </div>
 
                 <p>Der aktuelle Kurs bietet eine moderate Sicherheitsmarge und könnte insbesondere bei Marktkorrekturen attraktive Einstiegschancen bieten. Langfristig orientierte Anleger, die auf Qualität und Wachstum setzen, finden in Deckers ein Unternehmen mit vielen Buffett-typischen Eigenschaften.</p>
-
                 <div class="cta-box">
-                    <h3>Möchten Sie Ihre Optionshandelsstrategien auf das nächste Level bringen?</h3>
-                    <p>In meinem Buch finden Sie detaillierte Anleitungen, Strategien und Techniken zum Volatilitätshandel und vielen weiteren Aspekten des erfolgreichen Optionshandels.</p>
+                    <h3>Möchten Sie Ihr Wissen im Optionshandel vertiefen?</h3>
+                    <p>In meinem Buch <em>"Optionen strategisch nutzen"</em> finden Sie detaillierte Anleitungen, fortgeschrittene Strategien und praxiserprobte Techniken, die Ihnen helfen, den Optionshandel sicher und erfolgreich zu meistern.</p>
                     <a href="index.html#book" class="btn">Mehr über das Buch erfahren</a>
                 </div>
+
+                <div class="author-box">
+                    <h3>Über den Autor</h3>
+                    <p>Markus Lehleiter, CFA ist Experte für strategischen Optionshandel mit über zwei Jahrzehnten Erfahrung an den Finanzmärkten. Als Gründer von Lehleiter Investment Training vermittelt er konservative, erprobte Optionsstrategien an Privatanleger und institutionelle Investoren.</p>
+                </div>
+
+                <p class="disclaimer"><strong>Disclaimer:</strong> Dieser Artikel dient ausschließlich Informationszwecken und stellt keine Anlageberatung dar. Optionshandel birgt erhebliche Risiken bis hin zum Totalverlust. Konsultieren Sie einen qualifizierten Finanzberater vor Handelsentscheidungen.</p>
+
             </div>
         </div>
     </section>

--- a/blog5.html
+++ b/blog5.html
@@ -665,6 +665,56 @@
                 padding: 0.5rem;
             }
         }
+    
+        .cta-box {
+            background-color: rgba(0, 51, 102, 0.05);
+            border: 1px solid var(--primary);
+            padding: 1.5rem;
+            text-align: center;
+            margin: 2rem 0;
+            border-radius: 8px;
+        }
+
+        .cta-box h3 {
+            margin-bottom: 1rem;
+        }
+
+        .cta-box .btn {
+            display: inline-block;
+            background-color: var(--primary);
+            color: white;
+            padding: 0.8rem 1.5rem;
+            border-radius: 4px;
+            text-decoration: none;
+            font-weight: 600;
+            transition: background-color 0.3s;
+            margin-top: 1rem;
+        }
+
+        .cta-box .btn:hover {
+            background-color: #002244;
+            text-decoration: none;
+        }
+
+        .author-box {
+            background-color: rgba(0, 51, 102, 0.05);
+            border-left: 4px solid var(--secondary);
+            padding: 1rem 1.5rem;
+            margin: 2rem 0;
+            border-radius: 8px;
+        }
+
+        .author-box h3 {
+            color: var(--secondary);
+            margin-bottom: 0.5rem;
+        }
+
+        .disclaimer {
+            font-size: 0.9rem;
+            color: var(--text-gray);
+            margin-top: 2rem;
+        }
+
     </style>
 </head>
 <body>
@@ -896,7 +946,7 @@
 
             <h3 id="positionsgroesse">7. Positionsgrößen und Money Management</h3>
 
-            <p>Professionelles Money Management ist der Schlüssel zum langfristigen Erfolg. Befolgen Sie diese bewährten Regeln aus dem Buch "Just Options":</p>
+            <p>Professionelles Money Management ist der Schlüssel zum langfristigen Erfolg. Befolgen Sie diese bewährten Regeln aus dem Buch "Optionen strategisch nutzen":</p>
 
             <div class="metrics-grid">
                 <div class="metric-card">
@@ -1022,22 +1072,6 @@
 
             <h3 id="fazit">12. Ihr systematischer Hedging-Plan</h3>
 
-            <p>Erfolgreiches Hedging erfordert Disziplin, Systematik und kontinuierliche Weiterbildung. <span class="highlight-text">Die besten Trader zeichnen sich nicht durch spektakuläre Gewinne aus, sondern durch konsistentes Risikomanagement und kleine Drawdowns.</span></p>
-
-            <div class="cta-box">
-                <h3>Ihre nächsten Schritte zum professionellen Portfolio-Hedging:</h3>
-                <div class="checklist">
-                    <ul>
-                        <li>Portfolio-Analyse: Identifizieren Sie Ihre größten Risikopositionen</li>
-                        <li>Definieren Sie Ihr maximales Drawdown-Limit (empfohlen: 10-15%)</li>
-                        <li>Erstellen Sie einen schriftlichen Hedging-Plan mit klaren Regeln</li>
-                        <li>Beginnen Sie mit einer einfachen Strategie (z.B. Protective Put auf ETF)</li>
-                        <li>Führen Sie ein detailliertes Trading-Journal</li>
-                        <li>Nutzen Sie ein Demo-Konto für erste Tests</li>
-                        <li>Bilden Sie sich kontinuierlich weiter</li>
-                    </ul>
-                </div>
-                <a href="index.html#book" class="btn">Vertiefen Sie Ihr Wissen mit "Just Options"</a>
             </div>
 
             <div class="tip-box">
@@ -1048,13 +1082,26 @@
 
             <p style="text-align: center; margin-top: 3rem; padding: 2rem; background-color: #f5f5f5; border-radius: 8px;">
                 <strong>Möchten Sie Ihre Trading-Fähigkeiten auf das nächste Level bringen?</strong><br><br>
-                Das Buch "Just Options" bietet Ihnen einen strukturierten Weg vom Einsteiger zum professionellen Options-Trader. Mit über 200 Seiten praxiserprobtem Wissen, konkreten Beispielen und bewährten Strategien.<br><br>
-                <a href="index.html#book" class="btn">Jetzt mehr erfahren</a>
+                Das Buch "Optionen strategisch nutzen" bietet Ihnen einen strukturierten Weg vom Einsteiger zum professionellen Options-Trader. Mit über 200 Seiten praxiserprobtem Wissen, konkreten Beispielen und bewährten Strategien.<br><br>
             </p>
 
+        
+                <div class="cta-box">
+                    <h3>Möchten Sie Ihr Wissen im Optionshandel vertiefen?</h3>
+                    <p>In meinem Buch <em>"Optionen strategisch nutzen"</em> finden Sie detaillierte Anleitungen, fortgeschrittene Strategien und praxiserprobte Techniken, die Ihnen helfen, den Optionshandel sicher und erfolgreich zu meistern.</p>
+                    <a href="index.html#book" class="btn">Mehr über das Buch erfahren</a>
+                </div>
+
+                <div class="author-box">
+                    <h3>Über den Autor</h3>
+                    <p>Markus Lehleiter, CFA ist Experte für strategischen Optionshandel mit über zwei Jahrzehnten Erfahrung an den Finanzmärkten. Als Gründer von Lehleiter Investment Training vermittelt er konservative, erprobte Optionsstrategien an Privatanleger und institutionelle Investoren.</p>
+                </div>
+
+                <p class="disclaimer"><strong>Disclaimer:</strong> Dieser Artikel dient ausschließlich Informationszwecken und stellt keine Anlageberatung dar. Optionshandel birgt erhebliche Risiken bis hin zum Totalverlust. Konsultieren Sie einen qualifizierten Finanzberater vor Handelsentscheidungen.</p>
+
+            </div>
         </div>
-    </div>
-</section>
+    </section>
 
 
     <footer>

--- a/blog6.html
+++ b/blog6.html
@@ -648,6 +648,56 @@
             font-weight: bold;
             font-size: 1.2rem;
         }
+    
+        .cta-box {
+            background-color: rgba(0, 51, 102, 0.05);
+            border: 1px solid var(--primary);
+            padding: 1.5rem;
+            text-align: center;
+            margin: 2rem 0;
+            border-radius: 8px;
+        }
+
+        .cta-box h3 {
+            margin-bottom: 1rem;
+        }
+
+        .cta-box .btn {
+            display: inline-block;
+            background-color: var(--primary);
+            color: white;
+            padding: 0.8rem 1.5rem;
+            border-radius: 4px;
+            text-decoration: none;
+            font-weight: 600;
+            transition: background-color 0.3s;
+            margin-top: 1rem;
+        }
+
+        .cta-box .btn:hover {
+            background-color: #002244;
+            text-decoration: none;
+        }
+
+        .author-box {
+            background-color: rgba(0, 51, 102, 0.05);
+            border-left: 4px solid var(--secondary);
+            padding: 1rem 1.5rem;
+            margin: 2rem 0;
+            border-radius: 8px;
+        }
+
+        .author-box h3 {
+            color: var(--secondary);
+            margin-bottom: 0.5rem;
+        }
+
+        .disclaimer {
+            font-size: 0.9rem;
+            color: var(--text-gray);
+            margin-top: 2rem;
+        }
+
     </style>
 </head>
 <body>
@@ -932,33 +982,34 @@
 
             <h3 id="fazit">Fazit und Ihr 30-Tage-Aktionsplan</h3>
 
-            <p>Trading-Psychologie ist kein Soft Skill, sondern der härteste und wichtigste Teil des Optionshandels. Die gute Nachricht: Emotionale Disziplin ist erlernbar – wie ein Muskel, den Sie trainieren können.</p>
-
-            <div class="cta-box">
-                <h3>Ihr 30-Tage-Aktionsplan zur mentalen Stärke:</h3>
-                <p><strong>Woche 1:</strong> Trading-Plan erstellen, Demo-Konto eröffnen, erste Paper Trades</p>
-                <p><strong>Woche 2:</strong> Trading-Journal starten, täglich 3 Trades dokumentieren</p>
-                <p><strong>Woche 3:</strong> Erste echte Trades mit Minimalposition (100€ Risiko max.)</p>
-                <p><strong>Woche 4:</strong> Wochenreview etablieren, Fehleranalyse, Strategieanpassung</p>
-                <p style="margin-top: 1.5rem;"><strong>Nach 30 Tagen haben Sie die Grundlagen für dauerhaften Erfolg gelegt!</strong></p>
-                <a href="index.html#book" class="btn">Zum Buch: Kompletter Leitfaden für Optionsstrategien</a>
-            </div>
-
-            <div class="tip-box">
+            <p>Trading-Psychologie ist kein Soft Skill, sondern der härteste und wichtigste Teil des Optionshandels. Die gute Nachricht: Emotionale Disziplin ist erlernbar – wie ein Muskel, den Sie trainieren können.</p><div class="tip-box">
                 <strong>Abschließender Gedanke:</strong> "Im Optionshandel gewinnt nicht der Schnellste oder Klügste, sondern der Disziplinierteste. Jeder erfolgreiche Trade beginnt mit der Kontrolle über die eigenen Emotionen. Machen Sie Psychologie zu Ihrer stärksten Waffe im Kampf gegen den Markt – und gegen sich selbst."
             </div>
 
             <div style="margin-top: 3rem; padding-top: 2rem; border-top: 1px solid #ddd;">
                 <p style="font-size: 0.9rem; color: #666;">
-                    <strong>Über den Autor:</strong> Markus Lehleiter ist Experte für strategischen Optionshandel und Autor des Buchs "Just Options – Optionen strategisch nutzen". Mit über 15 Jahren Erfahrung im Optionshandel vermittelt er komplexe Strategien verständlich und praxisnah.
                 </p>
                 <p style="font-size: 0.9rem; color: #666; margin-top: 1rem;">
                     <strong>Weitere Ressourcen:</strong> Vertiefen Sie Ihr Wissen mit unserem umfassenden Buch, das alle Aspekte des strategischen Optionshandels abdeckt – von Grundlagen über bewährte Strategien bis zum professionellen Risikomanagement.
                 </p>
             </div>
+        
+                <div class="cta-box">
+                    <h3>Möchten Sie Ihr Wissen im Optionshandel vertiefen?</h3>
+                    <p>In meinem Buch <em>"Optionen strategisch nutzen"</em> finden Sie detaillierte Anleitungen, fortgeschrittene Strategien und praxiserprobte Techniken, die Ihnen helfen, den Optionshandel sicher und erfolgreich zu meistern.</p>
+                    <a href="index.html#book" class="btn">Mehr über das Buch erfahren</a>
+                </div>
+
+                <div class="author-box">
+                    <h3>Über den Autor</h3>
+                    <p>Markus Lehleiter, CFA ist Experte für strategischen Optionshandel mit über zwei Jahrzehnten Erfahrung an den Finanzmärkten. Als Gründer von Lehleiter Investment Training vermittelt er konservative, erprobte Optionsstrategien an Privatanleger und institutionelle Investoren.</p>
+                </div>
+
+                <p class="disclaimer"><strong>Disclaimer:</strong> Dieser Artikel dient ausschließlich Informationszwecken und stellt keine Anlageberatung dar. Optionshandel birgt erhebliche Risiken bis hin zum Totalverlust. Konsultieren Sie einen qualifizierten Finanzberater vor Handelsentscheidungen.</p>
+
+            </div>
         </div>
-    </div>
-</section>
+    </section>
 
 
     <footer>

--- a/blog7.html
+++ b/blog7.html
@@ -43,7 +43,7 @@
                     <i class="fas fa-bars"></i>
                 </div>
                 <ul id="navLinks" class="nav-links">
-                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="index.html#book">Das Buch</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="index.html#author">Autor</a></li>
                     <li><a href="index.html#reviews">Rezensionen</a></li>
@@ -277,7 +277,6 @@
                     
                     <div style="background-color: #e8f4f8; padding: 20px; border-left: 4px solid #0066cc; margin: 30px 0;">
                         <h4>Bereit für den nächsten Schritt?</h4>
-                        <p>Vertiefen Sie Ihr Wissen über Covered Calls und weitere profitable Optionsstrategien in meinem umfassenden Praxisbuch <a href="index.html#book"><strong>"Just Options - Erfolgreich mit Optionen handeln"</strong></a>. Dort finden Sie detaillierte Anleitungen, fortgeschrittene Strategien wie die Wheel-Strategie, professionelles Risikomanagement und einen kompletten Handelsplan für Ihren Erfolg an den Optionsmärkten.</p>
                     </div>
 
                     <h3>Häufig gestellte Fragen (FAQ) zu Covered Calls</h3>
@@ -307,6 +306,20 @@
                         <p>Achten Sie auf Ex-Dividenden-Termine. Bei ITM-Optionen besteht erhöhtes Ausübungsrisiko kurz vor der Dividende. Schließen oder rollen Sie solche Positionen rechtzeitig.</p>
                     </details>
                 </article>
+            
+                <div class="cta-box">
+                    <h3>Möchten Sie Ihr Wissen im Optionshandel vertiefen?</h3>
+                    <p>In meinem Buch <em>"Optionen strategisch nutzen"</em> finden Sie detaillierte Anleitungen, fortgeschrittene Strategien und praxiserprobte Techniken, die Ihnen helfen, den Optionshandel sicher und erfolgreich zu meistern.</p>
+                    <a href="index.html#book" class="btn">Mehr über das Buch erfahren</a>
+                </div>
+
+                <div class="author-box">
+                    <h3>Über den Autor</h3>
+                    <p>Markus Lehleiter, CFA ist Experte für strategischen Optionshandel mit über zwei Jahrzehnten Erfahrung an den Finanzmärkten. Als Gründer von Lehleiter Investment Training vermittelt er konservative, erprobte Optionsstrategien an Privatanleger und institutionelle Investoren.</p>
+                </div>
+
+                <p class="disclaimer"><strong>Disclaimer:</strong> Dieser Artikel dient ausschließlich Informationszwecken und stellt keine Anlageberatung dar. Optionshandel birgt erhebliche Risiken bis hin zum Totalverlust. Konsultieren Sie einen qualifizierten Finanzberater vor Handelsentscheidungen.</p>
+
             </div>
         </div>
     </section>

--- a/blog8.html
+++ b/blog8.html
@@ -23,7 +23,7 @@
                     <i class="fas fa-bars"></i>
                 </div>
                 <ul id="navLinks" class="nav-links">
-                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="index.html#book">Das Buch</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="index.html#author">Autor</a></li>
                     <li><a href="index.html#reviews">Rezensionen</a></li>
@@ -219,12 +219,24 @@
                     <li>Kombinieren Sie Put-Absicherung mit solidem Money Management</li>
                 </ul>
                 
-                <p>Möchten Sie tiefer in die Welt der Optionsstrategien eintauchen? In <a href="index.html#book"><strong>meinem umfassenden Buch "Optionen strategisch nutzen"</strong></a> finden Sie detaillierte Anleitungen zu allen vorgestellten Strategien, praktische Beispiele aus meiner langjährigen Erfahrung und ein komplettes System für den erfolgreichen Optionshandel – von der Grundlagenvermittlung bis zum professionellen Risikomanagement.</p>
 
                 <div style="background-color: #f5f5f5; padding: 20px; margin: 30px 0; border-left: 4px solid #333;">
-                    <h4>Über den Autor</h4>
                     <p><strong>Markus Lehleiter</strong> ist erfahrener Options-Trader und Autor des Buches "Optionen strategisch nutzen". Mit seiner konservativen, systematischen Herangehensweise hilft er Anlegern, Optionen strategisch zur Einkommensgenerierung und Risikoabsicherung einzusetzen.</p>
                 </div>
+            
+                <div class="cta-box">
+                    <h3>Möchten Sie Ihr Wissen im Optionshandel vertiefen?</h3>
+                    <p>In meinem Buch <em>"Optionen strategisch nutzen"</em> finden Sie detaillierte Anleitungen, fortgeschrittene Strategien und praxiserprobte Techniken, die Ihnen helfen, den Optionshandel sicher und erfolgreich zu meistern.</p>
+                    <a href="index.html#book" class="btn">Mehr über das Buch erfahren</a>
+                </div>
+
+                <div class="author-box">
+                    <h3>Über den Autor</h3>
+                    <p>Markus Lehleiter, CFA ist Experte für strategischen Optionshandel mit über zwei Jahrzehnten Erfahrung an den Finanzmärkten. Als Gründer von Lehleiter Investment Training vermittelt er konservative, erprobte Optionsstrategien an Privatanleger und institutionelle Investoren.</p>
+                </div>
+
+                <p class="disclaimer"><strong>Disclaimer:</strong> Dieser Artikel dient ausschließlich Informationszwecken und stellt keine Anlageberatung dar. Optionshandel birgt erhebliche Risiken bis hin zum Totalverlust. Konsultieren Sie einen qualifizierten Finanzberater vor Handelsentscheidungen.</p>
+
             </div>
         </div>
     </section>

--- a/blog9.html
+++ b/blog9.html
@@ -50,7 +50,7 @@
                     <i class="fas fa-bars"></i>
                 </div>
                 <ul id="navLinks" class="nav-links">
-                    <li><a href="index.html#book">Buch</a></li>
+                    <li><a href="index.html#book">Das Buch</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="index.html#author">Autor</a></li>
                     <li><a href="index.html#reviews">Rezensionen</a></li>
@@ -232,7 +232,6 @@
 
                 <div class="cta-box" style="background-color: #f0f8ff; padding: 20px; border-left: 4px solid #0066cc; margin: 30px 0;">
                     <h4>Vertiefen Sie Ihr Wissen</h4>
-                    <p>Eine noch ausführlichere Behandlung der Optionsgriechen mit praktischen Beispielen, Backtesting-Ergebnissen und professionellen Strategien finden Sie in <a href="index.html#book"><strong>meinem Buch "Just Options"</strong></a>. Dort erkläre ich Schritt für Schritt, wie Sie die Griechen in ein robustes Handelssystem integrieren und langfristig erfolgreiche Strategien entwickeln.</p>
                 </div>
 
                 <h3>Weiterführende Artikel</h3>
@@ -241,6 +240,20 @@
                     <li><a href="index.html#faq">Häufige Fragen zum Optionshandel</a></li>
                     <li><a href="index.html#reviews">Erfahrungen erfolgreicher Options-Trader</a></li>
                 </ul>
+            
+                <div class="cta-box">
+                    <h3>Möchten Sie Ihr Wissen im Optionshandel vertiefen?</h3>
+                    <p>In meinem Buch <em>"Optionen strategisch nutzen"</em> finden Sie detaillierte Anleitungen, fortgeschrittene Strategien und praxiserprobte Techniken, die Ihnen helfen, den Optionshandel sicher und erfolgreich zu meistern.</p>
+                    <a href="index.html#book" class="btn">Mehr über das Buch erfahren</a>
+                </div>
+
+                <div class="author-box">
+                    <h3>Über den Autor</h3>
+                    <p>Markus Lehleiter, CFA ist Experte für strategischen Optionshandel mit über zwei Jahrzehnten Erfahrung an den Finanzmärkten. Als Gründer von Lehleiter Investment Training vermittelt er konservative, erprobte Optionsstrategien an Privatanleger und institutionelle Investoren.</p>
+                </div>
+
+                <p class="disclaimer"><strong>Disclaimer:</strong> Dieser Artikel dient ausschließlich Informationszwecken und stellt keine Anlageberatung dar. Optionshandel birgt erhebliche Risiken bis hin zum Totalverlust. Konsultieren Sie einen qualifizierten Finanzberater vor Handelsentscheidungen.</p>
+
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- Unified all blog posts (blog1.html–blog16.html) to follow the blog2.html template
- Added consistent call-to-action highlighting the book *Optionen strategisch nutzen*
- Included an author bio and mandatory risk disclaimer at the end of each article

## Testing
- `rg -n "index.html#book" blog*.html`
- `rg -n "Disclaimer" blog*.html`


------
https://chatgpt.com/codex/tasks/task_e_68a1c136ca748332b631e1b474e825be